### PR TITLE
Correctly save role with quoted search path

### DIFF
--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -473,6 +473,9 @@ func readSearchPath(roleConfig pq.ByteaArray) []string {
 		config := string(v)
 		if strings.HasPrefix(config, roleSearchPathAttr) {
 			var result = strings.Split(strings.TrimPrefix(config, roleSearchPathAttr+"="), ", ")
+			for i := range result {
+				result[i] = strings.Trim(result[i], `"`)
+			}
 			return result
 		}
 	}

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -53,7 +53,7 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.sub_role", "name", "sub_role"),
 					resource.TestCheckResourceAttr("postgresql_role.sub_role", "roles.#", "2"),
 
-					testAccCheckPostgresqlRoleExists("role_with_search_path", nil, []string{"bar", "foo"}),
+					testAccCheckPostgresqlRoleExists("role_with_search_path", nil, []string{"bar", "foo-with-hyphen"}),
 
 					// The int part in the attr name is the schema.HashString of the value.
 					resource.TestCheckResourceAttr("postgresql_role.sub_role", "roles.719783566", "myrole2"),
@@ -346,6 +346,9 @@ func checkSearchPath(client *Client, roleName string, expectedSearchPath []strin
 	}
 
 	searchPath := strings.Split(searchPathStr, ", ")
+	for i := range searchPath {
+		searchPath[i] = strings.Trim(searchPath[i], `"`)
+	}
 	sort.Strings(expectedSearchPath)
 	if !reflect.DeepEqual(searchPath, expectedSearchPath) {
 		return fmt.Errorf(
@@ -411,6 +414,6 @@ resource "postgresql_role" "sub_role" {
 
 resource "postgresql_role" "role_with_search_path" {
   name = "role_with_search_path"
-  search_path = ["bar", "foo"]
+  search_path = ["bar", "foo-with-hyphen"]
 }
 `


### PR DESCRIPTION
(Moving https://github.com/hashicorp/terraform-provider-postgresql/pull/200 to new repository)

## Issue
When defining a search path in a PostgreSQL role which contains a hyphen it is saved as a quoted string in the DB. Once it is retrieved from the database the provider saves the quoted search path in the terraform state. Next time the changes are applied this is detected as a change that will be applied, although it actually is not a change.

## Solution
When reading the search path from PostgreSQL we have to trim the quotes.