### PR TITLE
Use lazy connections.

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -27,14 +27,9 @@ const (
 	featurePrivileges
 )
 
-type dbRegistryEntry struct {
-	db      *sql.DB
-	version semver.Version
-}
-
 var (
 	dbRegistryLock sync.Mutex
-	dbRegistry     map[string]dbRegistryEntry = make(map[string]dbRegistryEntry, 1)
+	dbRegistry     map[string]*DBConnection = make(map[string]*DBConnection, 1)
 
 	// Mapping of feature flags to versions
 	featureSupported = map[featureName]semver.Range{
@@ -68,6 +63,40 @@ var (
 	}
 )
 
+type DBConnection struct {
+	*sql.DB
+
+	client *Client
+
+	// version is the version number of the database as determined by parsing the
+	// output of `SELECT VERSION()`.x
+	version semver.Version
+}
+
+// featureSupported returns true if a given feature is supported or not. This is
+// slightly different from Config's featureSupported in that here we're
+// evaluating against the fingerprinted version, not the expected version.
+func (db *DBConnection) featureSupported(name featureName) bool {
+	fn, found := featureSupported[name]
+	if !found {
+		// panic'ing because this is a provider-only bug
+		panic(fmt.Sprintf("unknown feature flag %v", name))
+	}
+
+	return fn(db.version)
+}
+
+// isSuperuser returns true if connected user is a Postgres SUPERUSER
+func (db *DBConnection) isSuperuser() (bool, error) {
+	var superuser bool
+
+	if err := db.QueryRow("SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER").Scan(&superuser); err != nil {
+		return false, fmt.Errorf("could not check if current user is superuser: %w", err)
+	}
+
+	return superuser, nil
+}
+
 type ClientCertificateConfig struct {
 	CertificatePath string
 	KeyPath         string
@@ -98,14 +127,6 @@ type Client struct {
 
 	databaseName string
 
-	// db is a pointer to the DB connection.  Callers are responsible for
-	// releasing their connections.
-	db *sql.DB
-
-	// version is the version number of the database as determined by parsing the
-	// output of `SELECT VERSION()`.x
-	version semver.Version
-
 	// PostgreSQL lock on pg_catalog.  Many of the operations that Terraform
 	// performs are not permitted to be concurrent.  Unlike traditional
 	// PostgreSQL tables that use MVCC, many of the PostgreSQL system
@@ -115,50 +136,11 @@ type Client struct {
 }
 
 // NewClient returns client config for the specified database.
-func (c *Config) NewClient(database string) (*Client, error) {
-	dbRegistryLock.Lock()
-	defer dbRegistryLock.Unlock()
-
-	dsn := c.connStr(database)
-	dbEntry, found := dbRegistry[dsn]
-	if !found {
-		db, err := sql.Open("postgres", dsn)
-		if err != nil {
-			return nil, fmt.Errorf("Error connecting to PostgreSQL server: %w", err)
-		}
-
-		// We don't want to retain connection
-		// So when we connect on a specific database which might be managed by terraform,
-		// we don't keep opened connection in case of the db has to be dopped in the plan.
-		db.SetMaxIdleConns(0)
-		db.SetMaxOpenConns(c.MaxConns)
-
-		defaultVersion, _ := semver.Parse(defaultExpectedPostgreSQLVersion)
-		version := &c.ExpectedVersion
-		if defaultVersion.Equals(c.ExpectedVersion) {
-			// Version hint not set by user, need to fingerprint
-			version, err = fingerprintCapabilities(db)
-			if err != nil {
-				db.Close()
-				return nil, fmt.Errorf("error detecting capabilities: %w", err)
-			}
-		}
-
-		dbEntry = dbRegistryEntry{
-			db:      db,
-			version: *version,
-		}
-		dbRegistry[dsn] = dbEntry
-	}
-
-	client := Client{
+func (c *Config) NewClient(database string) *Client {
+	return &Client{
 		config:       *c,
 		databaseName: database,
-		db:           dbEntry.db,
-		version:      dbEntry.version,
 	}
-
-	return &client, nil
 }
 
 // featureSupported returns true if a given feature is supported or not.  This
@@ -301,11 +283,47 @@ func (c *Config) getDatabaseUsername() string {
 	return c.Username
 }
 
-// DB returns a copy to an sql.Open()'ed database connection.  Callers must
-// return their database resources.  Use of QueryRow() or Exec() is encouraged.
+// Connect returns a copy to an sql.Open()'ed database connection wrapped in a DBConnection struct.
+// Callers must return their database resources. Use of QueryRow() or Exec() is encouraged.
 // Query() must have their rows.Close()'ed.
-func (c *Client) DB() *sql.DB {
-	return c.db
+func (c *Client) Connect() (*DBConnection, error) {
+	dbRegistryLock.Lock()
+	defer dbRegistryLock.Unlock()
+
+	dsn := c.config.connStr(c.databaseName)
+	conn, found := dbRegistry[dsn]
+	if !found {
+		db, err := sql.Open("postgres", dsn)
+		if err != nil {
+			return nil, fmt.Errorf("Error connecting to PostgreSQL server: %w", err)
+		}
+
+		// We don't want to retain connection
+		// So when we connect on a specific database which might be managed by terraform,
+		// we don't keep opened connection in case of the db has to be dopped in the plan.
+		db.SetMaxIdleConns(0)
+		db.SetMaxOpenConns(c.config.MaxConns)
+
+		defaultVersion, _ := semver.Parse(defaultExpectedPostgreSQLVersion)
+		version := &c.config.ExpectedVersion
+		if defaultVersion.Equals(c.config.ExpectedVersion) {
+			// Version hint not set by user, need to fingerprint
+			version, err = fingerprintCapabilities(db)
+			if err != nil {
+				db.Close()
+				return nil, fmt.Errorf("error detecting capabilities: %w", err)
+			}
+		}
+
+		conn = &DBConnection{
+			db,
+			c,
+			*version,
+		}
+		dbRegistry[dsn] = conn
+	}
+
+	return conn, nil
 }
 
 // fingerprintCapabilities queries PostgreSQL to populate a local catalog of
@@ -332,28 +350,4 @@ func fingerprintCapabilities(db *sql.DB) (*semver.Version, error) {
 	}
 
 	return &version, nil
-}
-
-// featureSupported returns true if a given feature is supported or not. This is
-// slightly different from Config's featureSupported in that here we're
-// evaluating against the fingerprinted version, not the expected version.
-func (c *Client) featureSupported(name featureName) bool {
-	fn, found := featureSupported[name]
-	if !found {
-		// panic'ing because this is a provider-only bug
-		panic(fmt.Sprintf("unknown feature flag %v", name))
-	}
-
-	return fn(c.version)
-}
-
-// isSuperuser returns true if connected user is a Postgres SUPERUSER
-func (c *Client) isSuperuser() (bool, error) {
-	var superuser bool
-
-	if err := c.db.QueryRow("SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER").Scan(&superuser); err != nil {
-		return false, fmt.Errorf("could not check if current user is superuser: %w", err)
-	}
-
-	return superuser, nil
 }

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -10,6 +10,38 @@ import (
 	"github.com/lib/pq"
 )
 
+func PGResourceFunc(fn func(*DBConnection, *schema.ResourceData) error) func(*schema.ResourceData, interface{}) error {
+	return func(d *schema.ResourceData, meta interface{}) error {
+		client := meta.(*Client)
+
+		client.catalogLock.Lock()
+		defer client.catalogLock.Unlock()
+
+		db, err := client.Connect()
+		if err != nil {
+			return err
+		}
+
+		return fn(db, d)
+	}
+}
+
+func PGResourceExistsFunc(fn func(*DBConnection, *schema.ResourceData) (bool, error)) func(*schema.ResourceData, interface{}) (bool, error) {
+	return func(d *schema.ResourceData, meta interface{}) (bool, error) {
+		client := meta.(*Client)
+
+		client.catalogLock.Lock()
+		defer client.catalogLock.Unlock()
+
+		db, err := client.Connect()
+		if err != nil {
+			return false, err
+		}
+
+		return fn(db, d)
+	}
+}
+
 // QueryAble is a DB connection (sql.DB/Tx)
 type QueryAble interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
@@ -252,13 +284,13 @@ func pgArrayToSet(arr pq.ByteaArray) *schema.Set {
 // it will create a new connection pool if needed.
 func startTransaction(client *Client, database string) (*sql.Tx, error) {
 	if database != "" && database != client.databaseName {
-		var err error
-		client, err = client.config.NewClient(database)
-		if err != nil {
-			return nil, err
-		}
+		client = client.config.NewClient(database)
 	}
-	db := client.DB()
+	db, err := client.Connect()
+	if err != nil {
+		return nil, err
+	}
+
 	txn, err := db.Begin()
 	if err != nil {
 		return nil, fmt.Errorf("could not start transaction: %w", err)
@@ -328,14 +360,12 @@ func deferredRollback(txn *sql.Tx) {
 	}
 }
 
-func getDatabase(d *schema.ResourceData, client *Client) string {
-	database := client.databaseName
-
+func getDatabase(d *schema.ResourceData, databaseName string) string {
 	if v, ok := d.GetOk(extDatabaseAttr); ok {
-		database = v.(string)
+		databaseName = v.(string)
 	}
 
-	return database
+	return databaseName
 }
 
 func getDatabaseOwner(db QueryAble, database string) (string, error) {

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -182,10 +182,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
-	client, err := config.NewClient(d.Get("database").(string))
-	if err != nil {
-		return nil, fmt.Errorf("Error initializing PostgreSQL client: %w", err)
-	}
-
+	client := config.NewClient(d.Get("database").(string))
 	return client, nil
 }

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -539,16 +539,16 @@ func terminateBConnections(db *DBConnection, dbName string) error {
 	if db.featureSupported(featureDBAllowConnections) {
 		alterSql := fmt.Sprintf("ALTER DATABASE %s ALLOW_CONNECTIONS false", pq.QuoteIdentifier(dbName))
 
-		if _, err := c.DB().Exec(alterSql); err != nil {
+		if _, err := db.Exec(alterSql); err != nil {
 			return fmt.Errorf("Error blocking connections to database: %w", err)
 		}
 	}
 	pid := "procpid"
-	if c.featureSupported(featurePid) {
+	if db.featureSupported(featurePid) {
 		pid = "pid"
 	}
 	terminateSql = fmt.Sprintf("SELECT pg_terminate_backend(%s) FROM pg_stat_activity WHERE datname = '%s' AND %s <> pg_backend_pid()", pid, dbName, pid)
-	if _, err := c.DB().Exec(terminateSql); err != nil {
+	if _, err := db.Exec(terminateSql); err != nil {
 		return fmt.Errorf("Error terminating database connections: %w", err)
 	}
 

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -28,11 +28,11 @@ const (
 
 func resourcePostgreSQLDatabase() *schema.Resource {
 	return &schema.Resource{
-		Create: resourcePostgreSQLDatabaseCreate,
-		Read:   resourcePostgreSQLDatabaseRead,
-		Update: resourcePostgreSQLDatabaseUpdate,
-		Delete: resourcePostgreSQLDatabaseDelete,
-		Exists: resourcePostgreSQLDatabaseExists,
+		Create: PGResourceFunc(resourcePostgreSQLDatabaseCreate),
+		Read:   PGResourceFunc(resourcePostgreSQLDatabaseRead),
+		Update: PGResourceFunc(resourcePostgreSQLDatabaseUpdate),
+		Delete: PGResourceFunc(resourcePostgreSQLDatabaseDelete),
+		Exists: PGResourceExistsFunc(resourcePostgreSQLDatabaseExists),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -106,26 +106,19 @@ func resourcePostgreSQLDatabase() *schema.Resource {
 	}
 }
 
-func resourcePostgreSQLDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-
-	c.catalogLock.Lock()
-	defer c.catalogLock.Unlock()
-
-	if err := createDatabase(c, d); err != nil {
+func resourcePostgreSQLDatabaseCreate(db *DBConnection, d *schema.ResourceData) error {
+	if err := createDatabase(db, d); err != nil {
 		return err
 	}
 
 	d.SetId(d.Get(dbNameAttr).(string))
 
-	return resourcePostgreSQLDatabaseReadImpl(d, meta)
+	return resourcePostgreSQLDatabaseReadImpl(db, d)
 }
 
-func createDatabase(c *Client, d *schema.ResourceData) error {
-	currentUser := c.config.getDatabaseUsername()
+func createDatabase(db *DBConnection, d *schema.ResourceData) error {
+	currentUser := db.client.config.getDatabaseUsername()
 	owner := d.Get(dbOwnerAttr).(string)
-
-	db := c.DB()
 
 	var err error
 	if owner != "" {
@@ -200,7 +193,7 @@ func createDatabase(c *Client, d *schema.ResourceData) error {
 		fmt.Fprint(b, " TABLESPACE ", pq.QuoteIdentifier(v.(string)))
 	}
 
-	if c.featureSupported(featureDBAllowConnections) {
+	if db.featureSupported(featureDBAllowConnections) {
 		val := d.Get(dbAllowConnsAttr).(bool)
 		fmt.Fprint(b, " ALLOW_CONNECTIONS ", val)
 	}
@@ -210,13 +203,13 @@ func createDatabase(c *Client, d *schema.ResourceData) error {
 		fmt.Fprint(b, " CONNECTION LIMIT ", val)
 	}
 
-	if c.featureSupported(featureDBIsTemplate) {
+	if db.featureSupported(featureDBIsTemplate) {
 		val := d.Get(dbIsTemplateAttr).(bool)
 		fmt.Fprint(b, " IS_TEMPLATE ", val)
 	}
 
 	sql := b.String()
-	if _, err := c.DB().Exec(sql); err != nil {
+	if _, err := db.Exec(sql); err != nil {
 		return fmt.Errorf("Error creating database %q: %w", dbName, err)
 	}
 
@@ -225,46 +218,42 @@ func createDatabase(c *Client, d *schema.ResourceData) error {
 	return err
 }
 
-func resourcePostgreSQLDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-	c.catalogLock.Lock()
-	defer c.catalogLock.Unlock()
-
-	currentUser := c.config.getDatabaseUsername()
+func resourcePostgreSQLDatabaseDelete(db *DBConnection, d *schema.ResourceData) error {
+	currentUser := db.client.config.getDatabaseUsername()
 	owner := d.Get(dbOwnerAttr).(string)
 
 	var err error
 	if owner != "" {
 		// Needed in order to set the owner of the db if the connection user is not a
 		// superuser
-		ownerGranted, err := grantRoleMembership(c.DB(), owner, currentUser)
+		ownerGranted, err := grantRoleMembership(db, owner, currentUser)
 		if err != nil {
 			return err
 		}
 		if ownerGranted {
 			defer func() {
-				_, err = revokeRoleMembership(c.DB(), owner, currentUser)
+				_, err = revokeRoleMembership(db, owner, currentUser)
 			}()
 		}
 	}
 
 	dbName := d.Get(dbNameAttr).(string)
-	if c.featureSupported(featureDBIsTemplate) {
+	if db.featureSupported(featureDBIsTemplate) {
 		if isTemplate := d.Get(dbIsTemplateAttr).(bool); isTemplate {
 			// Template databases must have this attribute cleared before
 			// they can be dropped.
-			if err := doSetDBIsTemplate(c, dbName, false); err != nil {
+			if err := doSetDBIsTemplate(db, dbName, false); err != nil {
 				return fmt.Errorf("Error updating database IS_TEMPLATE during DROP DATABASE: %w", err)
 			}
 		}
 	}
 
-	if err := setDBIsTemplate(c, d); err != nil {
+	if err := setDBIsTemplate(db, d); err != nil {
 		return err
 	}
 
 	sql := fmt.Sprintf("DROP DATABASE %s", pq.QuoteIdentifier(dbName))
-	if _, err := c.DB().Exec(sql); err != nil {
+	if _, err := db.Exec(sql); err != nil {
 		return fmt.Errorf("Error dropping database: %w", err)
 	}
 
@@ -274,12 +263,8 @@ func resourcePostgreSQLDatabaseDelete(d *schema.ResourceData, meta interface{}) 
 	return err
 }
 
-func resourcePostgreSQLDatabaseExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	c := meta.(*Client)
-	c.catalogLock.RLock()
-	defer c.catalogLock.RUnlock()
-
-	txn, err := startTransaction(c, "")
+func resourcePostgreSQLDatabaseExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
+	txn, err := startTransaction(db.client, "")
 	if err != nil {
 		return false, err
 	}
@@ -288,20 +273,14 @@ func resourcePostgreSQLDatabaseExists(d *schema.ResourceData, meta interface{}) 
 	return dbExists(txn, d.Id())
 }
 
-func resourcePostgreSQLDatabaseRead(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-	c.catalogLock.RLock()
-	defer c.catalogLock.RUnlock()
-
-	return resourcePostgreSQLDatabaseReadImpl(d, meta)
+func resourcePostgreSQLDatabaseRead(db *DBConnection, d *schema.ResourceData) error {
+	return resourcePostgreSQLDatabaseReadImpl(db, d)
 }
 
-func resourcePostgreSQLDatabaseReadImpl(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-
+func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData) error {
 	dbId := d.Id()
 	var dbName, ownerName string
-	err := c.DB().QueryRow("SELECT d.datname, pg_catalog.pg_get_userbyid(d.datdba) from pg_database d WHERE datname=$1", dbId).Scan(&dbName, &ownerName)
+	err := db.QueryRow("SELECT d.datname, pg_catalog.pg_get_userbyid(d.datdba) from pg_database d WHERE datname=$1", dbId).Scan(&dbName, &ownerName)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL database (%q) not found", dbId)
@@ -326,7 +305,7 @@ func resourcePostgreSQLDatabaseReadImpl(d *schema.ResourceData, meta interface{}
 		`FROM pg_catalog.pg_database AS d, pg_catalog.pg_tablespace AS ts ` +
 		`WHERE d.datname = $1 AND d.dattablespace = ts.oid`
 	dbSQL := fmt.Sprintf(dbSQLFmt, strings.Join(columns, ", "))
-	err = c.DB().QueryRow(dbSQL, dbId).
+	err = db.QueryRow(dbSQL, dbId).
 		Scan(
 			&dbEncoding,
 			&dbCollation,
@@ -356,10 +335,10 @@ func resourcePostgreSQLDatabaseReadImpl(d *schema.ResourceData, meta interface{}
 	}
 	d.Set(dbTemplateAttr, dbTemplate)
 
-	if c.featureSupported(featureDBAllowConnections) {
+	if db.featureSupported(featureDBAllowConnections) {
 		var dbAllowConns bool
 		dbSQL := fmt.Sprintf(dbSQLFmt, "d.datallowconn")
-		err = c.DB().QueryRow(dbSQL, dbId).Scan(&dbAllowConns)
+		err = db.QueryRow(dbSQL, dbId).Scan(&dbAllowConns)
 		if err != nil {
 			return fmt.Errorf("Error reading ALLOW_CONNECTIONS property for DATABASE: %w", err)
 		}
@@ -367,10 +346,10 @@ func resourcePostgreSQLDatabaseReadImpl(d *schema.ResourceData, meta interface{}
 		d.Set(dbAllowConnsAttr, dbAllowConns)
 	}
 
-	if c.featureSupported(featureDBIsTemplate) {
+	if db.featureSupported(featureDBIsTemplate) {
 		var dbIsTemplate bool
 		dbSQL := fmt.Sprintf(dbSQLFmt, "d.datistemplate")
-		err = c.DB().QueryRow(dbSQL, dbId).Scan(&dbIsTemplate)
+		err = db.QueryRow(dbSQL, dbId).Scan(&dbIsTemplate)
 		if err != nil {
 			return fmt.Errorf("Error reading IS_TEMPLATE property for DATABASE: %w", err)
 		}
@@ -381,41 +360,37 @@ func resourcePostgreSQLDatabaseReadImpl(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourcePostgreSQLDatabaseUpdate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-	c.catalogLock.Lock()
-	defer c.catalogLock.Unlock()
-
-	if err := setDBName(c.DB(), d); err != nil {
+func resourcePostgreSQLDatabaseUpdate(db *DBConnection, d *schema.ResourceData) error {
+	if err := setDBName(db, d); err != nil {
 		return err
 	}
 
-	if err := setDBOwner(c, d); err != nil {
+	if err := setDBOwner(db, d); err != nil {
 		return err
 	}
 
-	if err := setDBTablespace(c.DB(), d); err != nil {
+	if err := setDBTablespace(db, d); err != nil {
 		return err
 	}
 
-	if err := setDBConnLimit(c.DB(), d); err != nil {
+	if err := setDBConnLimit(db, d); err != nil {
 		return err
 	}
 
-	if err := setDBAllowConns(c, d); err != nil {
+	if err := setDBAllowConns(db, d); err != nil {
 		return err
 	}
 
-	if err := setDBIsTemplate(c, d); err != nil {
+	if err := setDBIsTemplate(db, d); err != nil {
 		return err
 	}
 
 	// Empty values: ALTER DATABASE name RESET configuration_parameter;
 
-	return resourcePostgreSQLDatabaseReadImpl(d, meta)
+	return resourcePostgreSQLDatabaseReadImpl(db, d)
 }
 
-func setDBName(db *sql.DB, d *schema.ResourceData) error {
+func setDBName(db QueryAble, d *schema.ResourceData) error {
 	if !d.HasChange(dbNameAttr) {
 		return nil
 	}
@@ -436,7 +411,7 @@ func setDBName(db *sql.DB, d *schema.ResourceData) error {
 	return nil
 }
 
-func setDBOwner(c *Client, d *schema.ResourceData) error {
+func setDBOwner(db *DBConnection, d *schema.ResourceData) error {
 	if !d.HasChange(dbOwnerAttr) {
 		return nil
 	}
@@ -445,9 +420,7 @@ func setDBOwner(c *Client, d *schema.ResourceData) error {
 	if owner == "" {
 		return nil
 	}
-	currentUser := c.config.getDatabaseUsername()
-
-	db := c.DB()
+	currentUser := db.client.config.getDatabaseUsername()
 
 	//needed in order to set the owner of the db if the connection user is not a superuser
 	ownerGranted, err := grantRoleMembership(db, owner, currentUser)
@@ -469,7 +442,7 @@ func setDBOwner(c *Client, d *schema.ResourceData) error {
 	return err
 }
 
-func setDBTablespace(db *sql.DB, d *schema.ResourceData) error {
+func setDBTablespace(db QueryAble, d *schema.ResourceData) error {
 	if !d.HasChange(dbTablespaceAttr) {
 		return nil
 	}
@@ -490,7 +463,7 @@ func setDBTablespace(db *sql.DB, d *schema.ResourceData) error {
 	return nil
 }
 
-func setDBConnLimit(db *sql.DB, d *schema.ResourceData) error {
+func setDBConnLimit(db QueryAble, d *schema.ResourceData) error {
 	if !d.HasChange(dbConnLimitAttr) {
 		return nil
 	}
@@ -505,44 +478,44 @@ func setDBConnLimit(db *sql.DB, d *schema.ResourceData) error {
 	return nil
 }
 
-func setDBAllowConns(c *Client, d *schema.ResourceData) error {
+func setDBAllowConns(db *DBConnection, d *schema.ResourceData) error {
 	if !d.HasChange(dbAllowConnsAttr) {
 		return nil
 	}
 
-	if !c.featureSupported(featureDBAllowConnections) {
-		return fmt.Errorf("PostgreSQL client is talking with a server (%q) that does not support database ALLOW_CONNECTIONS", c.version.String())
+	if !db.featureSupported(featureDBAllowConnections) {
+		return fmt.Errorf("PostgreSQL client is talking with a server (%q) that does not support database ALLOW_CONNECTIONS", db.version.String())
 	}
 
 	allowConns := d.Get(dbAllowConnsAttr).(bool)
 	dbName := d.Get(dbNameAttr).(string)
 	sql := fmt.Sprintf("ALTER DATABASE %s ALLOW_CONNECTIONS %t", pq.QuoteIdentifier(dbName), allowConns)
-	if _, err := c.DB().Exec(sql); err != nil {
+	if _, err := db.Exec(sql); err != nil {
 		return fmt.Errorf("Error updating database ALLOW_CONNECTIONS: %w", err)
 	}
 
 	return nil
 }
 
-func setDBIsTemplate(c *Client, d *schema.ResourceData) error {
+func setDBIsTemplate(db *DBConnection, d *schema.ResourceData) error {
 	if !d.HasChange(dbIsTemplateAttr) {
 		return nil
 	}
 
-	if err := doSetDBIsTemplate(c, d.Get(dbNameAttr).(string), d.Get(dbIsTemplateAttr).(bool)); err != nil {
+	if err := doSetDBIsTemplate(db, d.Get(dbNameAttr).(string), d.Get(dbIsTemplateAttr).(bool)); err != nil {
 		return fmt.Errorf("Error updating database IS_TEMPLATE: %w", err)
 	}
 
 	return nil
 }
 
-func doSetDBIsTemplate(c *Client, dbName string, isTemplate bool) error {
-	if !c.featureSupported(featureDBIsTemplate) {
-		return fmt.Errorf("PostgreSQL client is talking with a server (%q) that does not support database IS_TEMPLATE", c.version.String())
+func doSetDBIsTemplate(db *DBConnection, dbName string, isTemplate bool) error {
+	if !db.featureSupported(featureDBIsTemplate) {
+		return fmt.Errorf("PostgreSQL client is talking with a server (%q) that does not support database IS_TEMPLATE", db.version.String())
 	}
 
 	sql := fmt.Sprintf("ALTER DATABASE %s IS_TEMPLATE %t", pq.QuoteIdentifier(dbName), isTemplate)
-	if _, err := c.DB().Exec(sql); err != nil {
+	if _, err := db.Exec(sql); err != nil {
 		return fmt.Errorf("Error updating database IS_TEMPLATE: %w", err)
 	}
 

--- a/postgresql/resource_postgresql_extension_test.go
+++ b/postgresql/resource_postgresql_extension_test.go
@@ -244,9 +244,12 @@ func testAccCreateExtensionDependency(tableName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		client := testAccProvider.Meta().(*Client)
-		db := client.DB()
+		db, err := client.Connect()
+		if err != nil {
+			return err
+		}
 
-		_, err := db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s; CREATE TABLE %s (id uuid DEFAULT gen_random_uuid())", tableName, tableName))
+		_, err = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s; CREATE TABLE %s (id uuid DEFAULT gen_random_uuid())", tableName, tableName))
 		if err != nil {
 			return fmt.Errorf("could not create test table in schema: %s", err)
 		}

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -40,11 +40,11 @@ const (
 
 func resourcePostgreSQLRole() *schema.Resource {
 	return &schema.Resource{
-		Create: resourcePostgreSQLRoleCreate,
-		Read:   resourcePostgreSQLRoleRead,
-		Update: resourcePostgreSQLRoleUpdate,
-		Delete: resourcePostgreSQLRoleDelete,
-		Exists: resourcePostgreSQLRoleExists,
+		Create: PGResourceFunc(resourcePostgreSQLRoleCreate),
+		Read:   PGResourceFunc(resourcePostgreSQLRoleRead),
+		Update: PGResourceFunc(resourcePostgreSQLRoleUpdate),
+		Delete: PGResourceFunc(resourcePostgreSQLRoleDelete),
+		Exists: PGResourceExistsFunc(resourcePostgreSQLRoleExists),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -164,12 +164,8 @@ func resourcePostgreSQLRole() *schema.Resource {
 	}
 }
 
-func resourcePostgreSQLRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-	c.catalogLock.Lock()
-	defer c.catalogLock.Unlock()
-
-	txn, err := c.DB().Begin()
+func resourcePostgreSQLRoleCreate(db *DBConnection, d *schema.ResourceData) error {
+	txn, err := startTransaction(db.client, "")
 	if err != nil {
 		return err
 	}
@@ -204,11 +200,11 @@ func resourcePostgreSQLRoleCreate(d *schema.ResourceData, meta interface{}) erro
 		// {roleEncryptedPassAttr, "ENCRYPTED", "UNENCRYPTED"},
 	}
 
-	if c.featureSupported(featureRLS) {
+	if db.featureSupported(featureRLS) {
 		boolOpts = append(boolOpts, boolOptType{roleBypassRLSAttr, "BYPASSRLS", "NOBYPASSRLS"})
 	}
 
-	if c.featureSupported(featureReplication) {
+	if db.featureSupported(featureReplication) {
 		boolOpts = append(boolOpts, boolOptType{roleReplicationAttr, "REPLICATION", "NOREPLICATION"})
 	}
 
@@ -269,7 +265,7 @@ func resourcePostgreSQLRoleCreate(d *schema.ResourceData, meta interface{}) erro
 	roleName := d.Get(roleNameAttr).(string)
 	createStr := strings.Join(createOpts, " ")
 	if len(createOpts) > 0 {
-		if c.featureSupported(featureCreateRoleWith) {
+		if db.featureSupported(featureCreateRoleWith) {
 			createStr = " WITH " + createStr
 		} else {
 			// NOTE(seanc@): Work around ParAccel/AWS RedShift's ancient fork of PostgreSQL
@@ -300,15 +296,11 @@ func resourcePostgreSQLRoleCreate(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(roleName)
 
-	return resourcePostgreSQLRoleReadImpl(c, d)
+	return resourcePostgreSQLRoleReadImpl(db, d)
 }
 
-func resourcePostgreSQLRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-	c.catalogLock.Lock()
-	defer c.catalogLock.Unlock()
-
-	txn, err := c.DB().Begin()
+func resourcePostgreSQLRoleDelete(db *DBConnection, d *schema.ResourceData) error {
+	txn, err := startTransaction(db.client, "")
 	if err != nil {
 		return err
 	}
@@ -318,7 +310,7 @@ func resourcePostgreSQLRoleDelete(d *schema.ResourceData, meta interface{}) erro
 
 	if !d.Get(roleSkipReassignOwnedAttr).(bool) {
 		if err := withRolesGranted(txn, []string{roleName}, func() error {
-			currentUser := c.config.getDatabaseUsername()
+			currentUser := db.client.config.getDatabaseUsername()
 			if _, err := txn.Exec(fmt.Sprintf("REASSIGN OWNED BY %s TO %s", pq.QuoteIdentifier(roleName), pq.QuoteIdentifier(currentUser))); err != nil {
 				return fmt.Errorf("could not reassign owned by role %s to %s: %w", roleName, currentUser, err)
 			}
@@ -346,13 +338,9 @@ func resourcePostgreSQLRoleDelete(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourcePostgreSQLRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	c := meta.(*Client)
-	c.catalogLock.RLock()
-	defer c.catalogLock.RUnlock()
-
+func resourcePostgreSQLRoleExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
 	var roleName string
-	err := c.DB().QueryRow("SELECT rolname FROM pg_catalog.pg_roles WHERE rolname=$1", d.Id()).Scan(&roleName)
+	err := db.QueryRow("SELECT rolname FROM pg_catalog.pg_roles WHERE rolname=$1", d.Id()).Scan(&roleName)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -363,15 +351,11 @@ func resourcePostgreSQLRoleExists(d *schema.ResourceData, meta interface{}) (boo
 	return true, nil
 }
 
-func resourcePostgreSQLRoleRead(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-	c.catalogLock.RLock()
-	defer c.catalogLock.RUnlock()
-
-	return resourcePostgreSQLRoleReadImpl(c, d)
+func resourcePostgreSQLRoleRead(db *DBConnection, d *schema.ResourceData) error {
+	return resourcePostgreSQLRoleReadImpl(db, d)
 }
 
-func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
+func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) error {
 	var roleSuperuser, roleInherit, roleCreateRole, roleCreateDB, roleCanLogin, roleReplication, roleBypassRLS bool
 	var roleConnLimit int
 	var roleName, roleValidUntil string
@@ -404,12 +388,12 @@ func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
 		&roleConfig,
 	}
 
-	if c.featureSupported(featureReplication) {
+	if db.featureSupported(featureReplication) {
 		columns = append(columns, "rolreplication")
 		values = append(values, &roleReplication)
 	}
 
-	if c.featureSupported(featureRLS) {
+	if db.featureSupported(featureRLS) {
 		columns = append(columns, "rolbypassrls")
 		values = append(values, &roleBypassRLS)
 	}
@@ -421,7 +405,7 @@ func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
 		// select columns
 		strings.Join(columns, ", "),
 	)
-	err := c.DB().QueryRow(roleSQL, roleID).Scan(values...)
+	err := db.QueryRow(roleSQL, roleID).Scan(values...)
 
 	switch {
 	case err == sql.ErrNoRows:
@@ -457,7 +441,7 @@ func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
 
 	d.SetId(roleName)
 
-	password, err := readRolePassword(c, d, roleCanLogin)
+	password, err := readRolePassword(db, d, roleCanLogin)
 	if err != nil {
 		return err
 	}
@@ -498,19 +482,19 @@ func readStatementTimeout(roleConfig pq.ByteaArray) (int, error) {
 
 // readRolePassword reads password either from Postgres if admin user is a superuser
 // or only from Terraform state.
-func readRolePassword(c *Client, d *schema.ResourceData, roleCanLogin bool) (string, error) {
+func readRolePassword(db *DBConnection, d *schema.ResourceData, roleCanLogin bool) (string, error) {
 	statePassword := d.Get(rolePasswordAttr).(string)
 
 	// Role which cannot login does not have password in pg_shadow.
 	// Also, if user specifies that admin is not a superuser we don't try to read pg_shadow
 	// (only superuser can read pg_shadow)
-	if !roleCanLogin || !c.config.Superuser {
+	if !roleCanLogin || !db.client.config.Superuser {
 		return statePassword, nil
 	}
 
 	// Otherwise we check if connected user is really a superuser
 	// (in order to warn user instead of having a permission denied error)
-	superuser, err := c.isSuperuser()
+	superuser, err := db.isSuperuser()
 	if err != nil {
 		return "", err
 	}
@@ -520,12 +504,12 @@ func readRolePassword(c *Client, d *schema.ResourceData, roleCanLogin bool) (str
 				"connected user %s is not a SUPERUSER. "+
 				"You can set `superuser = false` in the provider configuration "+
 				"so it will not try to read the password from Postgres",
-			c.config.getDatabaseUsername(),
+			db.client.config.getDatabaseUsername(),
 		)
 	}
 
 	var rolePassword string
-	err = c.DB().QueryRow("SELECT COALESCE(passwd, '') FROM pg_catalog.pg_shadow AS s WHERE s.usename = $1", d.Id()).Scan(&rolePassword)
+	err = db.QueryRow("SELECT COALESCE(passwd, '') FROM pg_catalog.pg_shadow AS s WHERE s.usename = $1", d.Id()).Scan(&rolePassword)
 	switch {
 	case err == sql.ErrNoRows:
 		// They don't have a password
@@ -555,12 +539,8 @@ func readRolePassword(c *Client, d *schema.ResourceData, roleCanLogin bool) (str
 	return rolePassword, nil
 }
 
-func resourcePostgreSQLRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-	c.catalogLock.Lock()
-	defer c.catalogLock.Unlock()
-
-	txn, err := c.DB().Begin()
+func resourcePostgreSQLRoleUpdate(db *DBConnection, d *schema.ResourceData) error {
+	txn, err := startTransaction(db.client, "")
 	if err != nil {
 		return err
 	}
@@ -574,7 +554,7 @@ func resourcePostgreSQLRoleUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if err := setRoleBypassRLS(c, txn, d); err != nil {
+	if err := setRoleBypassRLS(db, txn, d); err != nil {
 		return err
 	}
 
@@ -631,7 +611,7 @@ func resourcePostgreSQLRoleUpdate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("could not commit transaction: %w", err)
 	}
 
-	return resourcePostgreSQLRoleReadImpl(c, d)
+	return resourcePostgreSQLRoleReadImpl(db, d)
 }
 
 func setRoleName(txn *sql.Tx, d *schema.ResourceData) error {
@@ -673,13 +653,13 @@ func setRolePassword(txn *sql.Tx, d *schema.ResourceData) error {
 	return nil
 }
 
-func setRoleBypassRLS(c *Client, txn *sql.Tx, d *schema.ResourceData) error {
+func setRoleBypassRLS(db *DBConnection, txn *sql.Tx, d *schema.ResourceData) error {
 	if !d.HasChange(roleBypassRLSAttr) {
 		return nil
 	}
 
-	if !c.featureSupported(featureRLS) {
-		return fmt.Errorf("PostgreSQL client is talking with a server (%q) that does not support PostgreSQL Row-Level Security", c.version.String())
+	if !db.featureSupported(featureRLS) {
+		return fmt.Errorf("PostgreSQL client is talking with a server (%q) that does not support PostgreSQL Row-Level Security", db.version.String())
 	}
 
 	bypassRLS := d.Get(roleBypassRLSAttr).(bool)

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -274,8 +274,12 @@ func testAccCheckPostgresqlRoleExists(roleName string, grantedRoles []string, se
 }
 
 func checkRoleExists(client *Client, roleName string) (bool, error) {
+	db, err := client.Connect()
+	if err != nil {
+		return false, err
+	}
 	var _rez int
-	err := client.DB().QueryRow("SELECT 1 from pg_roles d WHERE rolname=$1", roleName).Scan(&_rez)
+	err = db.QueryRow("SELECT 1 from pg_roles d WHERE rolname=$1", roleName).Scan(&_rez)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -303,7 +307,12 @@ func testAccCheckRoleCanLogin(t *testing.T, role, password string) resource.Test
 }
 
 func checkGrantedRoles(client *Client, roleName string, expectedRoles []string) error {
-	rows, err := client.DB().Query(
+	db, err := client.Connect()
+	if err != nil {
+		return err
+	}
+
+	rows, err := db.Query(
 		"SELECT pg_get_userbyid(roleid) as rolname from pg_auth_members WHERE pg_get_userbyid(member) = $1 ORDER BY rolname",
 		roleName,
 	)
@@ -332,8 +341,13 @@ func checkGrantedRoles(client *Client, roleName string, expectedRoles []string) 
 }
 
 func checkSearchPath(client *Client, roleName string, expectedSearchPath []string) error {
+	db, err := client.Connect()
+	if err != nil {
+		return err
+	}
+
 	var searchPathStr string
-	err := client.DB().QueryRow(
+	err = db.QueryRow(
 		"SELECT (pg_options_to_table(rolconfig)).option_value FROM pg_roles WHERE rolname=$1;",
 		roleName,
 	).Scan(&searchPathStr)

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -31,11 +31,11 @@ const (
 
 func resourcePostgreSQLSchema() *schema.Resource {
 	return &schema.Resource{
-		Create: resourcePostgreSQLSchemaCreate,
-		Read:   resourcePostgreSQLSchemaRead,
-		Update: resourcePostgreSQLSchemaUpdate,
-		Delete: resourcePostgreSQLSchemaDelete,
-		Exists: resourcePostgreSQLSchemaExists,
+		Create: PGResourceFunc(resourcePostgreSQLSchemaCreate),
+		Read:   PGResourceFunc(resourcePostgreSQLSchemaRead),
+		Update: PGResourceFunc(resourcePostgreSQLSchemaUpdate),
+		Delete: PGResourceFunc(resourcePostgreSQLSchemaDelete),
+		Exists: PGResourceExistsFunc(resourcePostgreSQLSchemaExists),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -119,14 +119,9 @@ func resourcePostgreSQLSchema() *schema.Resource {
 	}
 }
 
-func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-
-	c.catalogLock.Lock()
-	defer c.catalogLock.Unlock()
-
-	database := getDatabase(d, c)
-	txn, err := startTransaction(c, database)
+func resourcePostgreSQLSchemaCreate(db *DBConnection, d *schema.ResourceData) error {
+	database := getDatabase(d, db.client.databaseName)
+	txn, err := startTransaction(db.client, database)
 	if err != nil {
 		return err
 	}
@@ -151,7 +146,7 @@ func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err := withRolesGranted(txn, rolesToGrant, func() error {
-		return createSchema(d, c, txn)
+		return createSchema(db, txn, d)
 	}); err != nil {
 		return err
 	}
@@ -160,12 +155,12 @@ func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error committing schema: %w", err)
 	}
 
-	d.SetId(generateSchemaID(d, c))
+	d.SetId(generateSchemaID(d, database))
 
-	return resourcePostgreSQLSchemaReadImpl(d, c)
+	return resourcePostgreSQLSchemaReadImpl(db, d)
 }
 
-func createSchema(d *schema.ResourceData, c *Client, txn *sql.Tx) error {
+func createSchema(db *DBConnection, txn *sql.Tx, d *schema.ResourceData) error {
 	schemaName := d.Get(schemaNameAttr).(string)
 
 	// Check if previous tasks haven't already create schema
@@ -176,7 +171,7 @@ func createSchema(d *schema.ResourceData, c *Client, txn *sql.Tx) error {
 	switch {
 	case err == sql.ErrNoRows:
 		b := bytes.NewBufferString("CREATE SCHEMA ")
-		if c.featureSupported(featureSchemaCreateIfNotExist) {
+		if db.featureSupported(featureSchemaCreateIfNotExist) {
 			if v := d.Get(schemaIfNotExists); v.(bool) {
 				fmt.Fprint(b, "IF NOT EXISTS ")
 			}
@@ -236,15 +231,10 @@ func createSchema(d *schema.ResourceData, c *Client, txn *sql.Tx) error {
 	return nil
 }
 
-func resourcePostgreSQLSchemaDelete(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
+func resourcePostgreSQLSchemaDelete(db *DBConnection, d *schema.ResourceData) error {
+	database := getDatabase(d, db.client.databaseName)
 
-	c.catalogLock.Lock()
-	defer c.catalogLock.Unlock()
-
-	database := getDatabase(d, c)
-
-	txn, err := startTransaction(c, database)
+	txn, err := startTransaction(db.client, database)
 	if err != nil {
 		return err
 	}
@@ -288,24 +278,19 @@ func resourcePostgreSQLSchemaDelete(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourcePostgreSQLSchemaExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	c := meta.(*Client)
-
-	c.catalogLock.RLock()
-	defer c.catalogLock.RUnlock()
-
-	database, schemaName, err := getDBSchemaName(d, c)
+func resourcePostgreSQLSchemaExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
+	database, schemaName, err := getDBSchemaName(d, db.client.databaseName)
 	if err != nil {
 		return false, err
 	}
 
 	// Check if the database exists
-	exists, err := dbExists(c.DB(), database)
+	exists, err := dbExists(db, database)
 	if err != nil || !exists {
 		return false, err
 	}
 
-	txn, err := startTransaction(c, database)
+	txn, err := startTransaction(db.client, database)
 	if err != nil {
 		return false, err
 	}
@@ -322,21 +307,17 @@ func resourcePostgreSQLSchemaExists(d *schema.ResourceData, meta interface{}) (b
 	return true, nil
 }
 
-func resourcePostgreSQLSchemaRead(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
-	c.catalogLock.RLock()
-	defer c.catalogLock.RUnlock()
-
-	return resourcePostgreSQLSchemaReadImpl(d, c)
+func resourcePostgreSQLSchemaRead(db *DBConnection, d *schema.ResourceData) error {
+	return resourcePostgreSQLSchemaReadImpl(db, d)
 }
 
-func resourcePostgreSQLSchemaReadImpl(d *schema.ResourceData, c *Client) error {
-	database, schemaName, err := getDBSchemaName(d, c)
+func resourcePostgreSQLSchemaReadImpl(db *DBConnection, d *schema.ResourceData) error {
+	database, schemaName, err := getDBSchemaName(d, db.client.databaseName)
 	if err != nil {
 		return err
 	}
 
-	txn, err := startTransaction(c, database)
+	txn, err := startTransaction(db.client, database)
 	if err != nil {
 		return err
 	}
@@ -379,27 +360,22 @@ func resourcePostgreSQLSchemaReadImpl(d *schema.ResourceData, c *Client) error {
 		d.Set(schemaNameAttr, schemaName)
 		d.Set(schemaOwnerAttr, schemaOwner)
 		d.Set(schemaDatabaseAttr, database)
-		d.SetId(generateSchemaID(d, c))
+		d.SetId(generateSchemaID(d, database))
 
 		return nil
 	}
 }
 
-func resourcePostgreSQLSchemaUpdate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*Client)
+func resourcePostgreSQLSchemaUpdate(db *DBConnection, d *schema.ResourceData) error {
+	databaseName := getDatabase(d, db.client.databaseName)
 
-	database := getDatabase(d, c)
-
-	c.catalogLock.Lock()
-	defer c.catalogLock.Unlock()
-
-	txn, err := startTransaction(c, database)
+	txn, err := startTransaction(db.client, databaseName)
 	if err != nil {
 		return err
 	}
 	defer deferredRollback(txn)
 
-	if err := setSchemaName(txn, d, c); err != nil {
+	if err := setSchemaName(txn, d, databaseName); err != nil {
 		return err
 	}
 
@@ -415,10 +391,10 @@ func resourcePostgreSQLSchemaUpdate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error committing schema: %w", err)
 	}
 
-	return resourcePostgreSQLSchemaReadImpl(d, c)
+	return resourcePostgreSQLSchemaReadImpl(db, d)
 }
 
-func setSchemaName(txn *sql.Tx, d *schema.ResourceData, c *Client) error {
+func setSchemaName(txn *sql.Tx, d *schema.ResourceData, databaseName string) error {
 	if !d.HasChange(schemaNameAttr) {
 		return nil
 	}
@@ -434,7 +410,7 @@ func setSchemaName(txn *sql.Tx, d *schema.ResourceData, c *Client) error {
 	if _, err := txn.Exec(sql); err != nil {
 		return fmt.Errorf("Error updating schema NAME: %w", err)
 	}
-	d.SetId(generateSchemaID(d, c))
+	d.SetId(generateSchemaID(d, databaseName))
 
 	return nil
 }
@@ -629,9 +605,9 @@ func schemaPolicyToACL(policyMap map[string]interface{}) acl.Schema {
 	return rolePolicy
 }
 
-func generateSchemaID(d *schema.ResourceData, c *Client) string {
+func generateSchemaID(d *schema.ResourceData, databaseName string) string {
 	SchemaID := strings.Join([]string{
-		getDatabase(d, c),
+		getDatabase(d, databaseName),
 		d.Get(schemaNameAttr).(string),
 	}, ".")
 
@@ -643,8 +619,8 @@ func getSchemaNameFromID(ID string) string {
 	return splitted[0]
 }
 
-func getDBSchemaName(d *schema.ResourceData, client *Client) (string, string, error) {
-	database := getDatabase(d, client)
+func getDBSchemaName(d *schema.ResourceData, databaseName string) (string, string, error) {
+	database := getDatabase(d, databaseName)
 	schemaName := d.Get(schemaNameAttr).(string)
 
 	// When importing, we have to parse the ID to find schema and database names.

--- a/postgresql/resource_postgresql_schema_test.go
+++ b/postgresql/resource_postgresql_schema_test.go
@@ -358,11 +358,11 @@ func checkSchemaExists(txn *sql.Tx, schemaName string) (bool, error) {
 func testAccCreateSchemaTable(database, schemaName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		client, err := testAccProvider.Meta().(*Client).config.NewClient(database)
+		client := testAccProvider.Meta().(*Client).config.NewClient(database)
+		db, err := client.Connect()
 		if err != nil {
-			return fmt.Errorf("could not create client on database %s: %w", schemaName, err)
+			return err
 		}
-		db := client.DB()
 
 		if _, err = db.Exec(fmt.Sprintf("CREATE TABLE %s.test_table (id serial)", schemaName)); err != nil {
 			return fmt.Errorf("could not create test table in schema %s: %s", schemaName, err)
@@ -374,11 +374,11 @@ func testAccCreateSchemaTable(database, schemaName string) resource.TestCheckFun
 
 func testAccCheckSchemaOwner(database, schemaName, expectedOwner string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client, err := testAccProvider.Meta().(*Client).config.NewClient(database)
+		client := testAccProvider.Meta().(*Client).config.NewClient(database)
+		db, err := client.Connect()
 		if err != nil {
-			return fmt.Errorf("could not create client on database %s: %w", schemaName, err)
+			return err
 		}
-		db := client.DB()
 
 		var owner string
 

--- a/postgresql/utils_test.go
+++ b/postgresql/utils_test.go
@@ -20,8 +20,12 @@ const (
 // Can be used in a PreCheck function to disable test based on feature.
 func testCheckCompatibleVersion(t *testing.T, feature featureName) {
 	client := testAccProvider.Meta().(*Client)
-	if !client.featureSupported(feature) {
-		t.Skip(fmt.Sprintf("Skip extension tests for Postgres %s", client.version))
+	db, err := client.Connect()
+	if err != nil {
+		t.Fatalf("could connect to database: %v", err)
+	}
+	if !db.featureSupported(feature) {
+		t.Skip(fmt.Sprintf("Skip extension tests for Postgres %s", db.version))
 	}
 }
 


### PR DESCRIPTION
This avoids the provider to try to connect even if no resources needed.
It also avoids the provider to try to connect when defining an RDS instance (for example) and some postgres resources in the same state.
(otherwise, at the first creation, provider will try to connect on a server which does not exist yet)


This replaces https://github.com/hashicorp/terraform-provider-postgresql/pull/199 and fixes https://github.com/hashicorp/terraform-provider-postgresql/issues/140 and https://github.com/hashicorp/terraform-provider-postgresql/issues/2