### PR TITLE
make postgresql_default_privileges postgres schema optional

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -255,9 +255,9 @@ func validatePrivileges(d *schema.ResourceData) error {
 	privileges := d.Get("privileges").(*schema.Set).List()
 
 	// Verify fields that are mandatory for specific object types
-	if objectType != "database" && d.Get("schema").(string) == "" {
+	/* if objectType != "database" && objectType != "table" && d.Get("schema").(string) == "" {
 		return fmt.Errorf("parameter 'schema' is mandatory for object_type %s", objectType)
-	}
+	} */
 
 	allowed, ok := allowedPrivileges[objectType]
 	if !ok {

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -254,11 +254,6 @@ func validatePrivileges(d *schema.ResourceData) error {
 	objectType := d.Get("object_type").(string)
 	privileges := d.Get("privileges").(*schema.Set).List()
 
-	// Verify fields that are mandatory for specific object types
-	/* if objectType != "database" && objectType != "table" && d.Get("schema").(string) == "" {
-		return fmt.Errorf("parameter 'schema' is mandatory for object_type %s", objectType)
-	} */
-
 	allowed, ok := allowedPrivileges[objectType]
 	if !ok {
 		return fmt.Errorf("unknown object type %s", objectType)

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -41,7 +41,7 @@ func resourcePostgreSQLDefaultPrivileges() *schema.Resource {
 			},
 			"schema": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 				Description: "The database schema to set default privileges for this role",
 			},
@@ -89,6 +89,7 @@ func resourcePostgreSQLDefaultPrivilegesRead(db *DBConnection, d *schema.Resourc
 }
 
 func resourcePostgreSQLDefaultPrivilegesCreate(db *DBConnection, d *schema.ResourceData) error {
+
 	if err := validatePrivileges(d); err != nil {
 		return err
 	}
@@ -169,21 +170,36 @@ func readRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 		return err
 	}
 
-	// This query aggregates the list of default privileges type (prtype)
-	// for the role (grantee), owner (grantor), schema (namespace name)
-	// and the specified object type (defaclobjtype).
-	query := `SELECT array_agg(prtype) FROM (
+	var query string
+	var queryArgs []interface{}
+
+	if pgSchema != "" {
+		query = `SELECT array_agg(prtype) FROM (
 		SELECT defaclnamespace, (aclexplode(defaclacl)).* FROM pg_default_acl
 		WHERE defaclobjtype = $3
 	) AS t (namespace, grantor_oid, grantee_oid, prtype, grantable)
-
 	JOIN pg_namespace ON pg_namespace.oid = namespace
 	WHERE grantee_oid = $1 AND nspname = $2 AND pg_get_userbyid(grantor_oid) = $4;
 `
+		queryArgs = []interface{}{roleOID, pgSchema, objectTypes[objectType], owner}
+	} else {
+		query = `SELECT array_agg(prtype) FROM (
+		SELECT defaclnamespace, (aclexplode(defaclacl)).* FROM pg_default_acl
+		WHERE defaclobjtype = $2
+	) AS t (namespace, grantor_oid, grantee_oid, prtype, grantable)
+	WHERE grantee_oid = $1 AND namespace = 0 AND pg_get_userbyid(grantor_oid) = $3;
+`
+		queryArgs = []interface{}{roleOID, objectTypes[objectType], owner}
+	}
+
+	// This query aggregates the list of default privileges type (prtype)
+	// for the role (grantee), owner (grantor), schema (namespace name)
+	// and the specified object type (defaclobjtype).
+
 	var privileges pq.ByteaArray
 
 	if err := txn.QueryRow(
-		query, roleOID, pgSchema, objectTypes[objectType], owner,
+		query, queryArgs...,
 	).Scan(&privileges); err != nil {
 		return fmt.Errorf("could not read default privileges: %w", err)
 	}
@@ -211,9 +227,16 @@ func grantRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 		privileges = append(privileges, priv.(string))
 	}
 
-	query := fmt.Sprintf("ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s GRANT %s ON %sS TO %s",
+	var inSchema string
+
+	// If a schema is specified we need to build the part of the query string to action this
+	if pgSchema != "" {
+		inSchema = fmt.Sprintf("IN SCHEMA %s", pq.QuoteIdentifier(pgSchema))
+	}
+
+	query := fmt.Sprintf("ALTER DEFAULT PRIVILEGES FOR ROLE %s %s GRANT %s ON %sS TO %s",
 		pq.QuoteIdentifier(d.Get("owner").(string)),
-		pq.QuoteIdentifier(pgSchema),
+		inSchema,
 		strings.Join(privileges, ","),
 		strings.ToUpper(d.Get("object_type").(string)),
 		pq.QuoteIdentifier(role),
@@ -230,10 +253,18 @@ func grantRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 }
 
 func revokeRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	pgSchema := d.Get("schema").(string)
+
+	var inSchema string
+
+	// If a schema is specified we need to build the part of the query string to action this
+	if pgSchema != "" {
+		inSchema = fmt.Sprintf("IN SCHEMA %s", pq.QuoteIdentifier(pgSchema))
+	}
 	query := fmt.Sprintf(
-		"ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s REVOKE ALL ON %sS FROM %s",
+		"ALTER DEFAULT PRIVILEGES FOR ROLE %s %s REVOKE ALL ON %sS FROM %s",
 		pq.QuoteIdentifier(d.Get("owner").(string)),
-		pq.QuoteIdentifier(d.Get("schema").(string)),
+		inSchema,
 		strings.ToUpper(d.Get("object_type").(string)),
 		pq.QuoteIdentifier(d.Get("role").(string)),
 	)
@@ -245,8 +276,14 @@ func revokeRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 }
 
 func generateDefaultPrivilegesID(d *schema.ResourceData) string {
+	pgSchema := d.Get("schema").(string)
+	if pgSchema == "" {
+		pgSchema = "noschema"
+	}
+
 	return strings.Join([]string{
-		d.Get("role").(string), d.Get("database").(string), d.Get("schema").(string),
+		d.Get("role").(string), d.Get("database").(string), pgSchema,
 		d.Get("owner").(string), d.Get("object_type").(string),
 	}, "_")
+
 }

--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -145,3 +145,80 @@ resource "postgresql_default_privileges" "test_ro" {
 		},
 	})
 }
+
+// Test the case where we define default priviliges without specifying a schema. These
+// priviliges should apply to newly created resources for the named role in all schema.
+func TestAccPostgresqlDefaultPrivileges_NoSchema(t *testing.T) {
+	skipIfNotAcc(t)
+
+	// We have to create the database outside of resource.Test
+	// because we need to create a table to assert that grant are correctly applied
+	// and we don't have this resource yet
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+
+	config := getTestConfig(t)
+	dbName, roleName := getTestDBNames(dbSuffix)
+
+	// Set default privileges to the test role then to public (i.e.: everyone)
+	for _, role := range []string{roleName, "public"} {
+		t.Run(role, func(t *testing.T) {
+
+			hclText := `
+resource "postgresql_default_privileges" "test_ro" {
+	database    = "%s"
+	owner       = "%s"
+	role        = "%s"
+	object_type = "table"
+	privileges   = %%s
+}
+`
+			// We set PGUSER as owner as he will create the test table
+			var tfConfig = fmt.Sprintf(hclText, dbName, config.Username, role)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(t)
+					testCheckCompatibleVersion(t, featurePrivileges)
+				},
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: fmt.Sprintf(tfConfig, `["SELECT"]`),
+						Check: resource.ComposeTestCheckFunc(
+							func(*terraform.State) error {
+								tables := []string{"test_schema.test_table", "dev_schema.test_table"}
+								// To test default privileges, we need to create tables
+								// in both dev and test schema after having applied the state.
+								dropFunc := createTestTables(t, dbSuffix, tables, "")
+								defer dropFunc()
+
+								return testCheckTablesPrivileges(t, dbName, roleName, tables, []string{"SELECT"})
+							},
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "object_type", "table"),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "1"),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.3138006342", "SELECT"),
+						),
+					},
+					{
+						Config: fmt.Sprintf(tfConfig, `["SELECT", "UPDATE"]`),
+						Check: resource.ComposeTestCheckFunc(
+							func(*terraform.State) error {
+								tables := []string{"test_schema.test_table", "dev_schema.test_table"}
+								// To test default privileges, we need to create tables
+								// in both dev and test schema after having applied the state.
+								dropFunc := createTestTables(t, dbSuffix, tables, "")
+								defer dropFunc()
+
+								return testCheckTablesPrivileges(t, dbName, roleName, tables, []string{"SELECT", "UPDATE"})
+							},
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "2"),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.3138006342", "SELECT"),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.1759376126", "UPDATE"),
+						),
+					},
+				},
+			})
+		})
+	}
+}

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -115,6 +115,11 @@ func resourcePostgreSQLGrantCreate(db *DBConnection, d *schema.ResourceData) err
 		)
 	}
 
+	// Verify schema is set for postgresql_grant
+	if d.Get("schema").(string) == "" && d.Get("object_type").(string) != "database" {
+		return fmt.Errorf("parameter 'schema' is mandatory for postgresql_grant resource")
+	}
+
 	if err := validatePrivileges(d); err != nil {
 		return err
 	}

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -442,7 +442,9 @@ func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, erro
 		return false, nil
 	}
 
-	if d.Get("object_type").(string) != "database" {
+	pgSchema := d.Get("schema").(string)
+
+	if d.Get("object_type").(string) != "database" && pgSchema != "" {
 		// Connect on this database to check if schema exists
 		dbTxn, err := startTransaction(client, database)
 		if err != nil {
@@ -451,7 +453,6 @@ func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, erro
 		defer dbTxn.Rollback()
 
 		// Check the schema exists (the SQL connection needs to be on the right database)
-		pgSchema := d.Get("schema").(string)
 		exists, err = schemaExists(dbTxn, pgSchema)
 		if err != nil {
 			return false, err

--- a/postgresql/utils_test.go
+++ b/postgresql/utils_test.go
@@ -111,6 +111,8 @@ func setupTestDatabase(t *testing.T, createDB, createRole bool) (string, func())
 		// Create a test schema in this new database and grant usage to rolName
 		dbExecute(t, config.connStr(dbName), "CREATE SCHEMA test_schema")
 		dbExecute(t, config.connStr(dbName), fmt.Sprintf("GRANT usage ON SCHEMA test_schema to %s", roleName))
+		dbExecute(t, config.connStr(dbName), "CREATE SCHEMA dev_schema")
+		dbExecute(t, config.connStr(dbName), fmt.Sprintf("GRANT usage ON SCHEMA dev_schema to %s", roleName))
 	}
 
 	return suffix, func() {


### PR DESCRIPTION
Hey,
This PR is to enable the postgres "schema" parameter to be optional when creating a "postgresql_default_privileges" resource. This was requested as a feature in issue #46.

Although the issue mentions using a query like:

```
alter default privileges revoke select on tables from $role;
```

The PR implements the feature using query as:

```
ALTER DEFAULT PRIVILEGES FOR ROLE %s GRANT %s ON %sS TO %s
```

This offers greater flexibility i.e. not just grant on resources created by the user making the ALTER request.

An acceptance test is also added to test the new functionality.
Please have a look at let me know what you think in the comments.