### PR TITLE
fix: Stop locking catalog for every resources.

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -141,13 +141,6 @@ type Client struct {
 	config Config
 
 	databaseName string
-
-	// PostgreSQL lock on pg_catalog.  Many of the operations that Terraform
-	// performs are not permitted to be concurrent.  Unlike traditional
-	// PostgreSQL tables that use MVCC, many of the PostgreSQL system
-	// catalogs look like tables, but are not in-fact able to be
-	// concurrently updated.
-	catalogLock sync.RWMutex
 }
 
 // NewClient returns client config for the specified database.

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -443,7 +443,7 @@ func getRoleOID(db QueryAble, role string) (int, error) {
 }
 
 func pgLockRole(txn *sql.Tx, role string) error {
-	if _, err := txn.Exec("SELECT pg_advisory_lock(oid::bigint) from pg_roles where rolname = $1", role); err != nil {
+	if _, err := txn.Exec("SELECT pg_advisory_xact_lock(oid::bigint) from pg_roles where rolname = $1", role); err != nil {
 		return fmt.Errorf("could not get advisory lock for role %s: %w", role, err)
 	}
 

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -452,7 +452,7 @@ func pgLockRole(txn *sql.Tx, role string) error {
 		"SELECT pg_advisory_xact_lock(member::bigint) FROM pg_auth_members JOIN pg_roles ON roleid = pg_roles.oid WHERE rolname = $1",
 		role,
 	); err != nil {
-		return fmt.Errorf("could not get advisory lock for role %s: %w", role, err)
+		return fmt.Errorf("could not get advisory lock for members of role %s: %w", role, err)
 	}
 
 	return nil

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -311,13 +311,17 @@ func resourcePostgreSQLRoleCreate(db *DBConnection, d *schema.ResourceData) erro
 }
 
 func resourcePostgreSQLRoleDelete(db *DBConnection, d *schema.ResourceData) error {
+	roleName := d.Get(roleNameAttr).(string)
+
 	txn, err := startTransaction(db.client, "")
 	if err != nil {
 		return err
 	}
 	defer deferredRollback(txn)
 
-	roleName := d.Get(roleNameAttr).(string)
+	if err := pgLockRole(txn, roleName); err != nil {
+		return err
+	}
 
 	if !d.Get(roleSkipReassignOwnedAttr).(bool) {
 		if err := withRolesGranted(txn, []string{roleName}, func() error {
@@ -583,6 +587,10 @@ func resourcePostgreSQLRoleUpdate(db *DBConnection, d *schema.ResourceData) erro
 		return err
 	}
 	defer deferredRollback(txn)
+
+	if err := pgLockRole(txn, d.Get(roleNameAttr).(string)); err != nil {
+		return err
+	}
 
 	if err := setRoleName(txn, d); err != nil {
 		return err

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -588,7 +588,8 @@ func resourcePostgreSQLRoleUpdate(db *DBConnection, d *schema.ResourceData) erro
 	}
 	defer deferredRollback(txn)
 
-	if err := pgLockRole(txn, d.Get(roleNameAttr).(string)); err != nil {
+	oldName, _ := d.GetChange(roleNameAttr)
+	if err := pgLockRole(txn, oldName.(string)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Historically, this provider takes a (golang) lock on a database for every resource of this database.
So only one create/update/delete of resource by database can be done at the same time.

(As it's a RWLock, read of resources can be parallelized)

Since #5 refactoring, I mistakenly change the lock which now takes a write lock even for read operations
(basically the plan part of Terraform). So provider was slower since v1.10

We could fix this and take a read lock for read operations as before but actually I don't see the point of this lock.
For me, most operations could be done at the same time.

Most of the request are now done in a transaction, the only risk is that a transaction will fail to commit
if multiple resources modifies the same database line.
That's the case for `postgresql_default_privileges`, one `pg_default_acl` row could represents multiple resources,
so this PR takes a lock on the owner role to avoid that.

This should make the provider way faster.

Tested with this code: https://github.com/cyrilgdn/terraform-provider-postgresql/tree/master/examples/issues/48

Fix #48