### PR TITLE
Add miss `drop_cascade` docs for `postgresql_extension`

### DIFF
--- a/website/docs/r/postgresql_extension.html.markdown
+++ b/website/docs/r/postgresql_extension.html.markdown
@@ -26,4 +26,4 @@ resource "postgresql_extension" "my_extension" {
 * `schema` - (Optional) Sets the schema of an extension.
 * `version` - (Optional) Sets the version number of the extension.
 * `database` - (Optional) Which database to create the extension on. Defaults to provider database.
-* `drop_cascade` - (Optional) "When true, will also drop all the objects that depend on the extension, and in turn all objects that depend on those objects. (Default: false)
+* `drop_cascade` - (Optional) When true, will also drop all the objects that depend on the extension, and in turn all objects that depend on those objects. (Default: false)

--- a/website/docs/r/postgresql_extension.html.markdown
+++ b/website/docs/r/postgresql_extension.html.markdown
@@ -26,3 +26,4 @@ resource "postgresql_extension" "my_extension" {
 * `schema` - (Optional) Sets the schema of an extension.
 * `version` - (Optional) Sets the version number of the extension.
 * `database` - (Optional) Which database to create the extension on. Defaults to provider database.
+* `drop_cascade` - (Optional) "When true, will also drop all the objects that depend on the extension, and in turn all objects that depend on those objects. (Default: false)


### PR DESCRIPTION
Exist in code, but not exist in docs 
https://github.com/cyrilgdn/terraform-provider-postgresql/blob/3f20f95eb61b41f93ccd3433becba0b70b5eae65/postgresql/resource_postgresql_extension.go#L59-L64