### PR TITLE
feat: add postgresql_physical_replication_slot

### DIFF
--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -136,14 +136,15 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"postgresql_database":           resourcePostgreSQLDatabase(),
-			"postgresql_default_privileges": resourcePostgreSQLDefaultPrivileges(),
-			"postgresql_extension":          resourcePostgreSQLExtension(),
-			"postgresql_grant":              resourcePostgreSQLGrant(),
-			"postgresql_grant_role":         resourcePostgreSQLGrantRole(),
-			"postgresql_replication_slot":   resourcePostgreSQLReplicationSlot(),
-			"postgresql_schema":             resourcePostgreSQLSchema(),
-			"postgresql_role":               resourcePostgreSQLRole(),
+			"postgresql_database":                  resourcePostgreSQLDatabase(),
+			"postgresql_default_privileges":        resourcePostgreSQLDefaultPrivileges(),
+			"postgresql_extension":                 resourcePostgreSQLExtension(),
+			"postgresql_grant":                     resourcePostgreSQLGrant(),
+			"postgresql_grant_role":                resourcePostgreSQLGrantRole(),
+			"postgresql_replication_slot":          resourcePostgreSQLReplicationSlot(),
+			"postgresql_physical_replication_slot": resourcePostgreSQLPhysicalReplicationSlot(),
+			"postgresql_schema":                    resourcePostgreSQLSchema(),
+			"postgresql_role":                      resourcePostgreSQLRole(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/postgresql/resource_postgresql_physical_replication_slot.go
+++ b/postgresql/resource_postgresql_physical_replication_slot.go
@@ -1,0 +1,69 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourcePostgreSQLPhysicalReplicationSlot() *schema.Resource {
+	return &schema.Resource{
+		Create: PGResourceFunc(resourcePostgreSQLPhysicalReplicationSlotCreate),
+		Read:   PGResourceFunc(resourcePostgreSQLPhysicalReplicationSlotRead),
+		Delete: PGResourceFunc(resourcePostgreSQLPhysicalReplicationSlotDelete),
+		Exists: PGResourceExistsFunc(resourcePostgreSQLPhysicalReplicationSlotExists),
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLPhysicalReplicationSlotCreate(db *DBConnection, d *schema.ResourceData) error {
+	name := d.Get("name").(string)
+	sql := "SELECT FROM pg_create_physical_replication_slot($1)"
+	if _, err := db.Exec(sql, name); err != nil {
+		return fmt.Errorf("could not create physical ReplicationSlot %s: %w", name, err)
+	}
+	d.SetId(name)
+
+	return nil
+}
+
+func resourcePostgreSQLPhysicalReplicationSlotExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
+	query := "SELECT 1 FROM pg_catalog.pg_replication_slots WHERE slot_name = $1 and slot_type = 'physical'"
+	var unused int
+	err := db.QueryRow(query, d.Id()).Scan(&unused)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, err
+	}
+
+	return true, nil
+}
+
+func resourcePostgreSQLPhysicalReplicationSlotRead(db *DBConnection, d *schema.ResourceData) error {
+	d.Set("name", d.Id())
+	return nil
+}
+
+func resourcePostgreSQLPhysicalReplicationSlotDelete(db *DBConnection, d *schema.ResourceData) error {
+
+	replicationSlotName := d.Get("name").(string)
+
+	if _, err := db.Exec("SELECT pg_drop_replication_slot($1)", replicationSlotName); err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/website/docs/r/postgresql_physical_replication_slot.markdown
+++ b/website/docs/r/postgresql_physical_replication_slot.markdown
@@ -1,0 +1,25 @@
+---
+layout: "postgresql"
+page_title: "PostgreSQL: postgresql_physical_replication_slot"
+sidebar_current: "docs-postgresql-resource-postgresql_physical_replication_slot"
+description: |-
+Creates and manages a physical replication slot on a PostgreSQL server.
+---
+
+# postgresql\_physical\_replication\_slot
+
+The ``postgresql_physical_replication_slot`` resource creates and manages a physical replication slot on a PostgreSQL
+server. This is useful to setup a cross datacenter replication, with Patroni for example, or permit
+any stand-by cluster to replicate physically data.
+
+
+## Usage
+
+```hcl
+resource "postgresql_physical_replication_slot" "my_slot" {
+  name  = "my_slot"
+}
+
+## Argument Reference
+
+* `name` - (Required) The name of the replication slot.


### PR DESCRIPTION
First, thanks for your work on this provider, it's very nice to handle majority of our usecases.

In our usecase at Veepee we use patroni to bootstrap PostgreSQL clusters and terraform to bootstrap users & databases.
For our Multi Datacenters setup we need fine grain replication slots in order to permit to promote a standby-leader
and move replication slots at the same time, to prevent empty slots.

The current postgresql_replication_slot is unable to handle the physical and as it's clearly not exactly the same way to handle both
we created  a custom resource for physical only