### PR TITLE
Gcppostgres pub priv ip selection

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -133,6 +133,7 @@ type Config struct {
 	ExpectedVersion   semver.Version
 	SSLClientCert     *ClientCertificateConfig
 	SSLRootCertPath   string
+	GCPIPAddrTypeOpts []string
 }
 
 // Client struct holding connection string

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/blang/semver"
 	_ "github.com/lib/pq" //PostgreSQL db
+	"gocloud.dev/gcp"
+	"gocloud.dev/gcp/cloudsql"
 	"gocloud.dev/postgres"
 	_ "gocloud.dev/postgres/awspostgres"
-	_ "gocloud.dev/postgres/gcppostgres"
+	"gocloud.dev/postgres/gcppostgres"
 )
 
 type featureName uint
@@ -240,6 +242,8 @@ func (c *Client) Connect() (*DBConnection, error) {
 		var err error
 		if c.config.Scheme == "postgres" {
 			db, err = sql.Open("postgres", dsn)
+		} else if c.config.Scheme == "gcppostgres" {
+			db, err = c.gcpPostgresOpen(context.Background(), dsn)
 		} else {
 			db, err = postgres.Open(context.Background(), dsn)
 		}
@@ -299,4 +303,37 @@ func fingerprintCapabilities(db *sql.DB) (*semver.Version, error) {
 	}
 
 	return &version, nil
+}
+
+// Decorator to avoid complexity on connect() funct
+func (c *Client) gcpPostgresOpen(ctx context.Context, dsn string) (*sql.DB, error) {
+
+	creds, err := gcp.DefaultCredentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := gcp.NewHTTPClient(gcp.DefaultTransport(), creds.TokenSource)
+	if err != nil {
+		return nil, err
+	}
+
+	certSource := cloudsql.NewCertSource(client)
+
+	// Override defaults with provider's configs
+	if c.config.GCPIPAddrTypeOpts != nil {
+		certSource.IPAddrTypes = c.config.GCPIPAddrTypeOpts
+	}
+
+	gcpOpener := gcppostgres.URLOpener{
+		CertSource: certSource,
+	}
+
+	// Parse URL
+	dsnUrl, err := url.Parse(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	return gcpOpener.OpenPostgresURL(ctx, dsnUrl)
 }

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -140,7 +140,9 @@ func Provider() terraform.ResourceProvider {
 					Type: schema.TypeString,
 				},
 				MaxItems: 2,
-				Default:  []string{"PRIMARY", "PRIVATE",},
+				MinItems: 1,
+
+				//Default:  []string{"PRIMARY", "PRIVATE"},
 			},
 		},
 

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -133,6 +133,15 @@ func Provider() terraform.ResourceProvider {
 				Description:  "Specify the expected version of PostgreSQL.",
 				ValidateFunc: validateExpectedVersion,
 			},
+			"gcp_ip_addr_type_opts": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				MaxItems: 2,
+				Default:  []string{"PRIMARY", "PRIVATE",},
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -192,6 +201,24 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 				CertificatePath: spec["cert"].(string),
 				KeyPath:         spec["key"].(string),
 			}
+		}
+	}
+
+	if data, ok := d.GetOk("gcp_ip_addr_type_opts"); ok {
+		ipAddrTypes := []string{}
+
+		if list, ok := data.([]interface{}); ok {
+			for _, valueRaw := range list {
+				if value, ok := valueRaw.(string); ok {
+					ipAddrTypes = append(ipAddrTypes, value)
+				}
+			}
+		}
+
+		if len(ipAddrTypes) > 0 {
+			config.GCPIPAddrTypeOpts = append(config.GCPIPAddrTypeOpts, ipAddrTypes...)
+		} else {
+			config.GCPIPAddrTypeOpts = nil
 		}
 	}
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -110,6 +110,11 @@ The following arguments are supported:
   Version](https://www.postgresql.org/support/versioning/) or `current`.  Once a
   connection has been established, Terraform will fingerprint the actual
   version.  Default: `9.0.0`.
+* `gcp_ip_addr_type_opts` - (Optional) Specify the type of connectivity to use on gcppostgres connections
+  ONLY FOR gcppostgres scheme. Valid values are:
+  * `["PRIMARY"]`: Uses instance's Public IP
+  * `["PRIVATE"]`: Uses instance's Private IP
+  * `["PRIMARY", "PRIVATE"]`: Default value, if the Instance has Public IP, if not uses Private IP
 
 ## GoCloud
 
@@ -156,6 +161,7 @@ provider "postgresql" {
   port     = 5432
   password = "test1234"
 
+  gcp_ip_addr_type_opts = ["PRIMARY", "PRIVATE"]
   superuser = false
 }
 ```


### PR DESCRIPTION
Trying this TF Provider for a personal use case came across the issue that I couldn't select which IP address I wanted to connect via the default behaviour of the provider.

This defaults to try the Public IP if the instance has one, then the Private IP.

For our use case we wanted an instance with both public and private IP addresses, which for 99% of the use cases would work fine for standard users. However for our use case the instance having the Public IP is due to external clients to connect to it, nonetheless our deployments infrastructure is under a very strictly controlled network which has public IP connectivity blocked of.

So with this solution we allow the provider to be able to select which interface of the GCP Cloud SQL (psql) it should connect to, therefore overriding the default behaviour of the "gocloud.dev" libraries.

I'm open to suggestions and improvements over this work as it was my first attempt on making changes on a TF provider.