### PR TITLE
allow empty list for postgresql_default_privileges

### DIFF
--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -100,6 +100,23 @@ resource "postgresql_default_privileges" "test_ro" {
 							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.1759376126", "UPDATE"),
 						),
 					},
+					{
+						Config: fmt.Sprintf(tfConfig, `[]`),
+						Check: resource.ComposeTestCheckFunc(
+							func(*terraform.State) error {
+								tables := []string{"test_schema.test_table"}
+								// To test default privileges, we need to create a table
+								// after having apply the state.
+								dropFunc := createTestTables(t, dbSuffix, tables, "")
+								defer dropFunc()
+
+								return testCheckTablesPrivileges(t, dbName, roleName, tables, []string{})
+							},
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "object_type", "table"),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "with_grant_option", fmt.Sprintf("%t", withGrant)),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "0"),
+						),
+					},
 				},
 			})
 		})

--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -49,6 +49,23 @@ resource "postgresql_default_privileges" "test_ro" {
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{
 					{
+						Config: fmt.Sprintf(tfConfig, `[]`),
+						Check: resource.ComposeTestCheckFunc(
+							func(*terraform.State) error {
+								tables := []string{"test_schema.test_table"}
+								// To test default privileges, we need to create a table
+								// after having apply the state.
+								dropFunc := createTestTables(t, dbSuffix, tables, "")
+								defer dropFunc()
+
+								return testCheckTablesPrivileges(t, dbName, roleName, tables, []string{})
+							},
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "object_type", "table"),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "with_grant_option", fmt.Sprintf("%t", withGrant)),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "0"),
+						),
+					},
+					{
 						Config: fmt.Sprintf(tfConfig, `["SELECT"]`),
 						Check: resource.ComposeTestCheckFunc(
 							func(*terraform.State) error {

--- a/website/docs/r/postgresql_default_privileges.html.markdown
+++ b/website/docs/r/postgresql_default_privileges.html.markdown
@@ -31,6 +31,21 @@ resource "postgresql_default_privileges" "read_only_tables" {
 * `role` - (Required) The name of the role to which grant default privileges on.
 * `database` - (Required) The database to grant default privileges for this role.
 * `owner` - (Required) Role for which apply default privileges (You can change default privileges only for objects that will be created by yourself or by roles that you are a member of).
-* `schema` - (Required) The database schema to set default privileges for this role.
+* `schema` - (Optional) The database schema to set default privileges for this role.
 * `object_type` - (Required) The PostgreSQL object type to set the default privileges on (one of: table, sequence, function, type).
-* `privileges` - (Required) The list of privileges to apply as default privileges.
+* `privileges` - (Required) The list of privileges to apply as default privileges. An empty list could be provided to revoke all default privileges for this role.
+
+
+## Examples
+
+Revoke default privileges for functions for "public" role:
+
+```hcl
+resource "postgresql_default_priviliges" "revoke_public" {
+  database    = postgresql_database.example_db.name
+  role        = "public"
+  owner       = "object_owner"
+  object_type = "function"
+  privileges  = []
+}
+```


### PR DESCRIPTION
Allows passing in an empty list to the `privileges` argument for the `postgresql_default_privileges` resource. This should allow the resource to be used to _only_ revoke certain privileges (e.g. `functions/procedures`).


Closes https://github.com/cyrilgdn/terraform-provider-postgresql/issues/117