### PR TITLE
postgresql_default_privileges: support of schema object type

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -29,6 +29,7 @@ const (
 	featureReplication
 	featureExtension
 	featurePrivileges
+	featurePrivilegesOnSchemas
 	featureForceDropDatabase
 	featurePid
 )
@@ -66,6 +67,10 @@ var (
 		// We do not support postgresql_grant and postgresql_default_privileges
 		// for Postgresql < 9.
 		featurePrivileges: semver.MustParseRange(">=9.0.0"),
+
+		// ALTER DEFAULT PRIVILEGES has ON SCHEMAS support
+		// for Postgresql >= 10
+		featurePrivilegesOnSchemas: semver.MustParseRange(">=10.0.0"),
 
 		// DROP DATABASE WITH FORCE
 		// for Postgresql >= 13

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -54,6 +54,7 @@ func resourcePostgreSQLDefaultPrivileges() *schema.Resource {
 					"sequence",
 					"function",
 					"type",
+					"schema",
 				}, false),
 				Description: "The PostgreSQL object type to set the default privileges on (one of: table, sequence, function, type)",
 			},
@@ -95,6 +96,12 @@ func resourcePostgreSQLDefaultPrivilegesRead(db *DBConnection, d *schema.Resourc
 }
 
 func resourcePostgreSQLDefaultPrivilegesCreate(db *DBConnection, d *schema.ResourceData) error {
+	pgSchema := d.Get("schema").(string)
+	objectType := d.Get("object_type").(string)
+
+	if pgSchema != "" && objectType == "schema" {
+		return fmt.Errorf("cannot specify `schema` when `object_type` is `schema`")
+	}
 
 	if d.Get("with_grant_option").(bool) && strings.ToLower(d.Get("role").(string)) == "public" {
 		return fmt.Errorf("with_grant_option cannot be true for role 'public'")

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -77,6 +77,16 @@ func resourcePostgreSQLDefaultPrivileges() *schema.Resource {
 }
 
 func resourcePostgreSQLDefaultPrivilegesRead(db *DBConnection, d *schema.ResourceData) error {
+	pgSchema := d.Get("schema").(string)
+	objectType := d.Get("object_type").(string)
+
+	if pgSchema != "" && objectType == "schema" && !db.featureSupported(featurePrivilegesOnSchemas) {
+		return fmt.Errorf(
+			"changing default privileges for schemas is not supported for this Postgres version (%s)",
+			db.version,
+		)
+	}
+
 	exists, err := checkRoleDBSchemaExists(db.client, d)
 	if err != nil {
 		return err
@@ -100,6 +110,12 @@ func resourcePostgreSQLDefaultPrivilegesCreate(db *DBConnection, d *schema.Resou
 	objectType := d.Get("object_type").(string)
 
 	if pgSchema != "" && objectType == "schema" {
+		if !db.featureSupported(featurePrivilegesOnSchemas) {
+			return fmt.Errorf(
+				"changing default privileges for schemas is not supported for this Postgres version (%s)",
+				db.version,
+			)
+		}
 		return fmt.Errorf("cannot specify `schema` when `object_type` is `schema`")
 	}
 
@@ -159,6 +175,15 @@ func resourcePostgreSQLDefaultPrivilegesCreate(db *DBConnection, d *schema.Resou
 
 func resourcePostgreSQLDefaultPrivilegesDelete(db *DBConnection, d *schema.ResourceData) error {
 	owner := d.Get("owner").(string)
+	pgSchema := d.Get("schema").(string)
+	objectType := d.Get("object_type").(string)
+
+	if pgSchema != "" && objectType == "schema" && !db.featureSupported(featurePrivilegesOnSchemas) {
+		return fmt.Errorf(
+			"changing default privileges for schemas is not supported for this Postgres version (%s)",
+			db.version,
+		)
+	}
 
 	txn, err := startTransaction(db.client, d.Get("database").(string))
 	if err != nil {

--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -34,8 +34,8 @@ resource "postgresql_default_privileges" "test_ro" {
 	database    = "%s"
 	owner       = "%s"
 	role        = "%s"
-	schema      = "test_schema"
-	object_type = "table"
+	schema      = %%s
+	object_type = %%s
 	with_grant_option = %t
 	privileges   = %%s
 }
@@ -49,7 +49,7 @@ resource "postgresql_default_privileges" "test_ro" {
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{
 					{
-						Config: fmt.Sprintf(tfConfig, `[]`),
+						Config: fmt.Sprintf(tfConfig, `"test_schema"`, `"table"`, `[]`),
 						Check: resource.ComposeTestCheckFunc(
 							func(*terraform.State) error {
 								tables := []string{"test_schema.test_table"}
@@ -66,7 +66,7 @@ resource "postgresql_default_privileges" "test_ro" {
 						),
 					},
 					{
-						Config: fmt.Sprintf(tfConfig, `["SELECT"]`),
+						Config: fmt.Sprintf(tfConfig, `"test_schema"`, `"table"`, `["SELECT"]`),
 						Check: resource.ComposeTestCheckFunc(
 							func(*terraform.State) error {
 								tables := []string{"test_schema.test_table"}
@@ -84,7 +84,7 @@ resource "postgresql_default_privileges" "test_ro" {
 						),
 					},
 					{
-						Config: fmt.Sprintf(tfConfig, `["SELECT", "UPDATE"]`),
+						Config: fmt.Sprintf(tfConfig, `"test_schema"`, `"table"`, `["SELECT", "UPDATE"]`),
 						Check: resource.ComposeTestCheckFunc(
 							func(*terraform.State) error {
 								tables := []string{"test_schema.test_table"}
@@ -101,7 +101,7 @@ resource "postgresql_default_privileges" "test_ro" {
 						),
 					},
 					{
-						Config: fmt.Sprintf(tfConfig, `[]`),
+						Config: fmt.Sprintf(tfConfig, `"test_schema"`, `"table"`, `[]`),
 						Check: resource.ComposeTestCheckFunc(
 							func(*terraform.State) error {
 								tables := []string{"test_schema.test_table"}
@@ -115,6 +115,43 @@ resource "postgresql_default_privileges" "test_ro" {
 							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "object_type", "table"),
 							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "with_grant_option", fmt.Sprintf("%t", withGrant)),
 							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "0"),
+						),
+					},
+					{
+						Config: fmt.Sprintf(tfConfig, `null`, `"schema"`, `[]`),
+						Check: resource.ComposeTestCheckFunc(
+							func(*terraform.State) error {
+								schemas := []string{"test_schema2"}
+								// To test default privileges, we need to create a schema
+								// after having apply the state.
+								dropFunc := createTestSchemas(t, dbSuffix, schemas, "")
+								defer dropFunc()
+
+								return testCheckSchemasPrivileges(t, dbName, roleName, schemas, []string{})
+							},
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "object_type", "schema"),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "with_grant_option", fmt.Sprintf("%t", withGrant)),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "0"),
+						),
+					},
+					{
+						Config: fmt.Sprintf(tfConfig, `null`, `"schema"`, `["CREATE", "USAGE"]`),
+						Check: resource.ComposeTestCheckFunc(
+							func(*terraform.State) error {
+								schemas := []string{"test_schema2"}
+								// To test default privileges, we need to create a schema
+								// after having apply the state.
+								dropFunc := createTestSchemas(t, dbSuffix, schemas, "")
+								defer dropFunc()
+
+								return testCheckSchemasPrivileges(t, dbName, roleName, schemas, []string{"CREATE", "USAGE"})
+							},
+							resource.TestCheckResourceAttr(
+								"postgresql_default_privileges.test_ro", "id", fmt.Sprintf("%s_%s_noschema_postgres_schema", role, dbName),
+							),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "2"),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.2133731197", "CREATE"),
+							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.666868928", "USAGE"),
 						),
 					},
 				},

--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -147,7 +147,7 @@ resource "postgresql_default_privileges" "test_ro" {
 								return testCheckSchemasPrivileges(t, dbName, roleName, schemas, []string{"CREATE", "USAGE"})
 							},
 							resource.TestCheckResourceAttr(
-								"postgresql_default_privileges.test_ro", "id", fmt.Sprintf("%s_%s_noschema_postgres_schema", role, dbName),
+								"postgresql_default_privileges.test_ro", "id", fmt.Sprintf("%s_%s_noschema_%s_schema", role, dbName, config.Username),
 							),
 							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "2"),
 							resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.2133731197", "CREATE"),

--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -268,7 +268,7 @@ func TestAccPostgresqlDefaultPrivilegesOnSchemas(t *testing.T) {
 	skipIfNotAcc(t)
 
 	// We have to create the database outside of resource.Test
-	// because we need to create a table to assert that grant are correctly applied
+	// because we need to create schemas to assert that grant are correctly applied
 	// and we don't have this resource yet
 	dbSuffix, teardown := setupTestDatabase(t, true, true)
 	defer teardown()

--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -159,6 +159,7 @@ resource "postgresql_default_privileges" "test_ro" {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testCheckCompatibleVersion(t, featurePrivileges)
+			testCheckCompatibleVersion(t, featurePrivilegesOnSchemas)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -28,6 +28,7 @@ var objectTypes = map[string]string{
 	"sequence": "S",
 	"function": "f",
 	"type":     "T",
+	"schema":   "n",
 }
 
 func resourcePostgreSQLGrant() *schema.Resource {


### PR DESCRIPTION
This allows managing default privileges for schemas. The feature is available since PostgreSQL 10. Closes #34 