### PR TITLE
feat: Added column level access

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -245,7 +245,7 @@ var allowedPrivileges = map[string][]string{
 	"type":                 {"ALL", "USAGE"},
 	"foreign_data_wrapper": {"ALL", "USAGE"},
 	"foreign_server":       {"ALL", "USAGE"},
-	"column":               []string{"ALL", "SELECT", "INSERT", "UPDATE", "REFERENCES"},
+	"column":               {"ALL", "SELECT", "INSERT", "UPDATE", "REFERENCES"},
 }
 
 // validatePrivileges checks that privileges to apply are allowed for this object type.

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -245,6 +245,7 @@ var allowedPrivileges = map[string][]string{
 	"type":                 {"ALL", "USAGE"},
 	"foreign_data_wrapper": {"ALL", "USAGE"},
 	"foreign_server":       {"ALL", "USAGE"},
+	"column":               []string{"ALL", "SELECT", "INSERT", "UPDATE", "REFERENCES"},
 }
 
 // validatePrivileges checks that privileges to apply are allowed for this object type.
@@ -279,6 +280,17 @@ func setToPgIdentList(schema string, idents *schema.Set) string {
 		quotedIdents[i] = fmt.Sprintf(
 			"%s.%s",
 			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(ident.(string)),
+		)
+	}
+	return strings.Join(quotedIdents, ",")
+}
+
+func setToPgIdentSimpleList(idents *schema.Set) string {
+	quotedIdents := make([]string, idents.Len())
+	for i, ident := range idents.List() {
+		quotedIdents[i] = fmt.Sprintf(
+			"%s",
+			ident.(string),
 		)
 	}
 	return strings.Join(quotedIdents, ",")

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -285,6 +285,14 @@ func setToPgIdentList(schema string, idents *schema.Set) string {
 	return strings.Join(quotedIdents, ",")
 }
 
+func setToPgIdentListWithoutSchema(idents *schema.Set) string {
+	quotedIdents := make([]string, idents.Len())
+	for i, ident := range idents.List() {
+		quotedIdents[i] = pq.QuoteIdentifier(ident.(string))
+	}
+	return strings.Join(quotedIdents, ",")
+}
+
 func setToPgIdentSimpleList(idents *schema.Set) string {
 	quotedIdents := make([]string, idents.Len())
 	for i, ident := range idents.List() {

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -288,10 +288,7 @@ func setToPgIdentList(schema string, idents *schema.Set) string {
 func setToPgIdentSimpleList(idents *schema.Set) string {
 	quotedIdents := make([]string, idents.Len())
 	for i, ident := range idents.List() {
-		quotedIdents[i] = fmt.Sprintf(
-			"%s",
-			ident.(string),
-		)
+		quotedIdents[i] = ident.(string)
 	}
 	return strings.Join(quotedIdents, ",")
 }

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -554,14 +554,10 @@ func createGrantQuery(d *schema.ResourceData, privileges []string) string {
 		)
 	case "COLUMN":
 		objects := d.Get("objects").(*schema.Set)
-		columns := []string{}
-		for _, col := range d.Get("columns").(*schema.Set).List() {
-			columns = append(columns, col.(string))
-		}
 		query = fmt.Sprintf(
 			"GRANT %s (%s) ON TABLE %s TO %s",
 			strings.Join(privileges, ","),
-			strings.Join(columns, ","),
+			setToPgIdentListWithoutSchema(d.Get("columns").(*schema.Set)),
 			setToPgIdentList(d.Get("schema").(string), objects),
 			pq.QuoteIdentifier(d.Get("role").(string)),
 		)
@@ -634,7 +630,7 @@ func createRevokeQuery(d *schema.ResourceData) string {
 			query = fmt.Sprintf(
 				"REVOKE %s (%s) ON TABLE %s FROM %s",
 				setToPgIdentSimpleList(privileges),
-				setToPgIdentSimpleList(columns),
+				setToPgIdentListWithoutSchema(columns),
 				setToPgIdentList(d.Get("schema").(string), objects),
 				pq.QuoteIdentifier(d.Get("role").(string)),
 			)

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -23,6 +23,7 @@ var allowedObjectTypes = []string{
 	"table",
 	"foreign_data_wrapper",
 	"foreign_server",
+	"column",
 }
 
 var objectTypes = map[string]string{
@@ -36,8 +37,9 @@ var objectTypes = map[string]string{
 func resourcePostgreSQLGrant() *schema.Resource {
 	return &schema.Resource{
 		Create: PGResourceFunc(resourcePostgreSQLGrantCreate),
-		// As create revokes and grants we can use it to update too
-		Update: PGResourceFunc(resourcePostgreSQLGrantCreate),
+		// Since all of this resource's arguments force a recreation
+		// there's no need for an Update function
+		//Update:
 		Read:   PGResourceFunc(resourcePostgreSQLGrantRead),
 		Delete: PGResourceFunc(resourcePostgreSQLGrantDelete),
 
@@ -75,9 +77,18 @@ func resourcePostgreSQLGrant() *schema.Resource {
 				Set:         schema.HashString,
 				Description: "The specific objects to grant privileges on for this role (empty means all objects of the requested type)",
 			},
+			"columns": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Description: "The specific columns to grant privileges on for this role",
+			},
 			"privileges": {
 				Type:        schema.TypeSet,
 				Required:    true,
+				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Set:         schema.HashString,
 				Description: "The list of privileges to grant",
@@ -129,6 +140,18 @@ func resourcePostgreSQLGrantCreate(db *DBConnection, d *schema.ResourceData) err
 	}
 	if d.Get("objects").(*schema.Set).Len() > 0 && (objectType == "database" || objectType == "schema") {
 		return fmt.Errorf("cannot specify `objects` when `object_type` is `database` or `schema`")
+	}
+	if d.Get("columns").(*schema.Set).Len() > 0 && (objectType != "column") {
+		return fmt.Errorf("cannot specify `columns` when `object_type` is not `column`")
+	}
+	if d.Get("columns").(*schema.Set).Len() == 0 && (objectType == "column") {
+		return fmt.Errorf("must specify `columns` when `object_type` is `column`")
+	}
+	if d.Get("privileges").(*schema.Set).Len() != 1 && (objectType == "column") {
+		return fmt.Errorf("must specify exactly 1 `privileges` when `object_type` is `column`")
+	}
+	if (d.Get("objects").(*schema.Set).Len() != 1) && (objectType == "column") {
+		return fmt.Errorf("must specify exactly 1 table in the `objects` field when `object_type` is `column`")
 	}
 	if d.Get("objects").(*schema.Set).Len() != 1 && (objectType == "foreign_data_wrapper" || objectType == "foreign_server") {
 		return fmt.Errorf("one element must be specified in `objects` when `object_type` is `foreign_data_wrapper` or `foreign_server`")
@@ -314,6 +337,7 @@ func readRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 	role := d.Get("role").(string)
 	objectType := d.Get("object_type").(string)
 	objects := d.Get("objects").(*schema.Set)
+	privileges := d.Get("privileges").(*schema.Set)
 
 	roleOID, err := getRoleOID(txn, role)
 	if err != nil {
@@ -354,6 +378,48 @@ GROUP BY pg_proc.proname
 `
 		rows, err = txn.Query(
 			query, roleOID, d.Get("schema"),
+		)
+
+	case "column":
+		// The following query is made up of 3 parts
+		// The first one simply aggregates all privileges on one column in one table into one line.
+		// The second part fetches all permissions on all columns for a given user & a given table in a give schema.
+		// The third part fetches all table-level permissions for the aforementioned table.
+		// Subtracting the third part from the second part allows us
+		// to get column-level privileges without those created by table-level privileges.
+		query = `
+SELECT table_name, array_agg(privilege_type) AS column_privileges
+FROM (
+  SELECT table_name, column_name, privilege_type
+  FROM information_schema.column_privileges
+    WHERE
+      grantee = $1
+    AND
+      table_schema = $2
+    AND
+      table_name = $3
+    AND
+      privilege_type = $6
+  EXCEPT
+  SELECT pg_class.relname, pg_attribute.attname, privilege_type AS table_grant
+  FROM pg_class
+  JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+  LEFT JOIN (
+    SELECT acls.*
+    FROM
+      (SELECT relname, relnamespace, relkind, (aclexplode(relacl)).* FROM pg_class c) as acls
+    WHERE grantee=$4
+    ) privs
+  USING (relname, relnamespace, relkind)
+  LEFT JOIN pg_attribute ON pg_class.oid = pg_attribute.attrelid
+  WHERE nspname = $2 AND relkind = $5 AND attname NOT IN ('ctid', 'cmax', 'cmin', 'tableoid', 'xmin', 'xmax')
+  )
+AS col_privs_without_table_privs
+GROUP BY col_privs_without_table_privs.table_name, col_privs_without_table_privs.column_name
+ORDER BY col_privs_without_table_privs.column_name
+;`
+		rows, err = txn.Query(
+			query, role, d.Get("schema"), objects.List()[0], roleOID, objectTypes["table"], privileges.List()[0],
 		)
 
 	default:
@@ -448,6 +514,19 @@ func createGrantQuery(d *schema.ResourceData, privileges []string) string {
 			pq.QuoteIdentifier(srvName.(string)),
 			pq.QuoteIdentifier(d.Get("role").(string)),
 		)
+	case "COLUMN":
+		objects := d.Get("objects").(*schema.Set)
+		columns := []string{}
+		for _, col := range d.Get("columns").(*schema.Set).List() {
+			columns = append(columns, col.(string))
+		}
+		query = fmt.Sprintf(
+			"GRANT %s (%s) ON TABLE %s TO %s",
+			strings.Join(privileges, ","),
+			strings.Join(columns, ","),
+			setToPgIdentList(d.Get("schema").(string), objects),
+			pq.QuoteIdentifier(d.Get("role").(string)),
+		)
 	case "TABLE", "SEQUENCE", "FUNCTION", "PROCEDURE", "ROUTINE":
 		objects := d.Get("objects").(*schema.Set)
 		if objects.Len() > 0 {
@@ -506,15 +585,37 @@ func createRevokeQuery(d *schema.ResourceData) string {
 			pq.QuoteIdentifier(srvName.(string)),
 			pq.QuoteIdentifier(d.Get("role").(string)),
 		)
+	case "COLUMN":
+		objects := d.Get("objects").(*schema.Set)
+		columns := d.Get("columns").(*schema.Set)
+		privileges := d.Get("privileges").(*schema.Set)
+		query = fmt.Sprintf(
+			"REVOKE %s (%s) ON TABLE %s FROM %s",
+			setToPgIdentSimpleList(privileges),
+			setToPgIdentSimpleList(columns),
+			setToPgIdentList(d.Get("schema").(string), objects),
+			pq.QuoteIdentifier(d.Get("role").(string)),
+		)
 	case "TABLE", "SEQUENCE", "FUNCTION", "PROCEDURE", "ROUTINE":
 		objects := d.Get("objects").(*schema.Set)
+		privileges := d.Get("privileges").(*schema.Set)
 		if objects.Len() > 0 {
-			query = fmt.Sprintf(
-				"REVOKE ALL PRIVILEGES ON %s %s FROM %s",
-				strings.ToUpper(d.Get("object_type").(string)),
-				setToPgIdentList(d.Get("schema").(string), objects),
-				pq.QuoteIdentifier(d.Get("role").(string)),
-			)
+			if privileges.Len() > 0 {
+				query = fmt.Sprintf(
+					"REVOKE %s ON %s %s FROM %s",
+					setToPgIdentSimpleList(privileges),
+					strings.ToUpper(d.Get("object_type").(string)),
+					setToPgIdentList(d.Get("schema").(string), objects),
+					pq.QuoteIdentifier(d.Get("role").(string)),
+				)
+			} else {
+				query = fmt.Sprintf(
+					"REVOKE ALL PRIVILEGES ON %s %s FROM %s",
+					strings.ToUpper(d.Get("object_type").(string)),
+					setToPgIdentList(d.Get("schema").(string), objects),
+					pq.QuoteIdentifier(d.Get("role").(string)),
+				)
+			}
 		} else {
 			query = fmt.Sprintf(
 				"REVOKE ALL PRIVILEGES ON ALL %sS IN SCHEMA %s FROM %s",
@@ -619,6 +720,10 @@ func generateGrantID(d *schema.ResourceData) string {
 
 	for _, object := range d.Get("objects").(*schema.Set).List() {
 		parts = append(parts, object.(string))
+	}
+
+	for _, column := range d.Get("columns").(*schema.Set).List() {
+		parts = append(parts, column.(string))
 	}
 
 	return strings.Join(parts, "_")

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -652,13 +652,18 @@ func createRevokeQuery(d *schema.ResourceData) string {
 		objects := d.Get("objects").(*schema.Set)
 		columns := d.Get("columns").(*schema.Set)
 		privileges := d.Get("privileges").(*schema.Set)
-		query = fmt.Sprintf(
-			"REVOKE %s (%s) ON TABLE %s FROM %s",
-			setToPgIdentSimpleList(privileges),
-			setToPgIdentSimpleList(columns),
-			setToPgIdentList(d.Get("schema").(string), objects),
-			pq.QuoteIdentifier(d.Get("role").(string)),
-		)
+		if privileges.Len() == 0 || columns.Len() == 0 {
+			// No privileges to revoke, so don't revoke anything
+			query = "SELECT NULL"
+		} else {
+			query = fmt.Sprintf(
+				"REVOKE %s (%s) ON TABLE %s FROM %s",
+				setToPgIdentSimpleList(privileges),
+				setToPgIdentSimpleList(columns),
+				setToPgIdentList(d.Get("schema").(string), objects),
+				pq.QuoteIdentifier(d.Get("role").(string)),
+			)
+		}
 	case "TABLE", "SEQUENCE", "FUNCTION", "PROCEDURE", "ROUTINE":
 		objects := d.Get("objects").(*schema.Set)
 		if objects.Len() > 0 {

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -425,6 +425,9 @@ func TestAccPostgresqlGrantColumns(t *testing.T) {
 					func(*terraform.State) error {
 						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"SELECT"}, []string{"test_column_one", "test_column_two"})
 					},
+					func(*terraform.State) error {
+						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{""}, []string{"test_column_one", "var"})
+					},
 				),
 			},
 			{

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -125,7 +125,7 @@ func TestCreateGrantQuery(t *testing.T) {
 				"role":        roleName,
 			}),
 			privileges: []string{"SELECT"},
-			expected:   fmt.Sprintf(`GRANT SELECT (col2,col1) ON TABLE %[1]s."o1" TO %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+			expected:   fmt.Sprintf(`GRANT SELECT (%[2]s,%[3]s) ON TABLE %[1]s."o1" TO %[4]s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier("col2"), pq.QuoteIdentifier("col1"), pq.QuoteIdentifier(roleName)),
 		},
 		{
 			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
@@ -270,7 +270,7 @@ func TestCreateRevokeQuery(t *testing.T) {
 				"role":        roleName,
 				"privileges":  []interface{}{"SELECT"},
 			}),
-			expected: fmt.Sprintf(`REVOKE SELECT (col2,col1) ON TABLE %[1]s."o1" FROM %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+			expected: fmt.Sprintf(`REVOKE SELECT ("col2","col1") ON TABLE %[1]s."o1" FROM %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
 		},
 		{
 			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -387,7 +387,7 @@ func TestAccPostgresqlGrantColumns(t *testing.T) {
 	dbSuffix, teardown := setupTestDatabase(t, true, true)
 	defer teardown()
 
-	testTables := []string{"test_schema.test_table", "test_schema.test_table2"}
+	testTables := []string{"test_schema.test_table"}
 	createTestTables(t, dbSuffix, testTables, "")
 
 	dbName, roleName := getTestDBNames(dbSuffix)
@@ -415,8 +415,10 @@ func TestAccPostgresqlGrantColumns(t *testing.T) {
 				Config: fmt.Sprintf(testGrant, `["test_column_one", "test_column_two"]`, `["SELECT"]`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.#", "1"),
-					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.4260833613", "test_table"),
-					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.3138006342", "SELECT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.0", "test_table"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "columns.#", "2"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.0", "SELECT"),
 					func(*terraform.State) error {
 						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"SELECT"}, []string{"test_column_one"})
 					},
@@ -429,8 +431,11 @@ func TestAccPostgresqlGrantColumns(t *testing.T) {
 				Config: fmt.Sprintf(testGrant, `["test_column_one", "test_column_two"]`, `["INSERT"]`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.#", "1"),
-					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.4260833613", "test_table"),
-					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.892623219", "INSERT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.0", "test_table"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "columns.#", "2"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "columns.0", "test_column_one"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.0", "INSERT"),
 					func(*terraform.State) error {
 						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"INSERT"}, []string{`"test_column_one"`})
 					},
@@ -443,8 +448,12 @@ func TestAccPostgresqlGrantColumns(t *testing.T) {
 				Config: fmt.Sprintf(testGrant, `["test_column_one", "test_column_two"]`, `["UPDATE"]`),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.#", "1"),
-					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.4260833613", "test_table"),
-					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.1759376126", "UPDATE"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.0", "test_table"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "columns.#", "2"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "columns.0", "test_column_one"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.0", "UPDATE"),
+
 					func(*terraform.State) error {
 						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"UPDATE"}, []string{"test_column_one"})
 					},

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -15,6 +15,7 @@ func TestCreateGrantQuery(t *testing.T) {
 	var databaseName = "foo"
 	var roleName = "bar"
 	var tableObjects = []interface{}{"o1", "o2"}
+	var tableColumns = []interface{}{"col1", "col2"}
 	var fdwObjects = []interface{}{"baz"}
 
 	cases := []struct {
@@ -117,6 +118,17 @@ func TestCreateGrantQuery(t *testing.T) {
 		},
 		{
 			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "column",
+				"objects":     []interface{}{"o1"},
+				"columns":     tableColumns,
+				"schema":      databaseName,
+				"role":        roleName,
+			}),
+			privileges: []string{"SELECT"},
+			expected:   fmt.Sprintf(`GRANT SELECT (col2,col1) ON TABLE %[1]s."o1" TO %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
 				"object_type": "foreign_data_wrapper",
 				"objects":     fdwObjects,
 				"role":        roleName,
@@ -167,6 +179,7 @@ func TestCreateRevokeQuery(t *testing.T) {
 	var databaseName = "foo"
 	var roleName = "bar"
 	var tableObjects = []interface{}{"o1", "o2"}
+	var tableColumns = []interface{}{"col1", "col2"}
 	var fdwObjects = []interface{}{"baz"}
 
 	cases := []struct {
@@ -237,6 +250,27 @@ func TestCreateRevokeQuery(t *testing.T) {
 				"role":        roleName,
 			}),
 			expected: fmt.Sprintf(`REVOKE ALL PRIVILEGES ON TABLE %[1]s."o2",%[1]s."o1" FROM %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "table",
+				"objects":     tableObjects,
+				"schema":      databaseName,
+				"role":        roleName,
+				"privileges":  []interface{}{"INSERT", "UPDATE"},
+			}),
+			expected: fmt.Sprintf(`REVOKE UPDATE,INSERT ON TABLE %[1]s."o2",%[1]s."o1" FROM %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "column",
+				"objects":     []interface{}{"o1"},
+				"schema":      databaseName,
+				"columns":     tableColumns,
+				"role":        roleName,
+				"privileges":  []interface{}{"SELECT"},
+			}),
+			expected: fmt.Sprintf(`REVOKE SELECT (col2,col1) ON TABLE %[1]s."o1" FROM %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
 		},
 		{
 			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
@@ -340,6 +374,82 @@ func TestAccPostgresqlGrant(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.#", "0"),
 					func(*terraform.State) error {
 						return testCheckTablesPrivileges(t, dbName, roleName, testTables, []string{})
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlGrantColumns(t *testing.T) {
+	skipIfNotAcc(t)
+
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+
+	testTables := []string{"test_schema.test_table", "test_schema.test_table2"}
+	createTestTables(t, dbSuffix, testTables, "")
+
+	dbName, roleName := getTestDBNames(dbSuffix)
+
+	var testGrant = fmt.Sprintf(`
+	resource "postgresql_grant" "test" {
+		database    = "%s"
+		role        = "%s"
+		schema      = "test_schema"
+		object_type = "column"
+		objects     = ["test_table"]
+		columns     = %%s
+		privileges  = %%s
+	}
+	`, dbName, roleName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featurePrivileges)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testGrant, `["test_column_one", "test_column_two"]`, `["SELECT"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.4260833613", "test_table"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.3138006342", "SELECT"),
+					func(*terraform.State) error {
+						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"SELECT"}, []string{"test_column_one"})
+					},
+					func(*terraform.State) error {
+						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"SELECT"}, []string{"test_column_one", "test_column_two"})
+					},
+				),
+			},
+			{
+				Config: fmt.Sprintf(testGrant, `["test_column_one", "test_column_two"]`, `["INSERT"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.4260833613", "test_table"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.892623219", "INSERT"),
+					func(*terraform.State) error {
+						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"INSERT"}, []string{`"test_column_one"`})
+					},
+					func(*terraform.State) error {
+						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"INSERT"}, []string{`"test_column_one"`, `"test_column_two"`})
+					},
+				),
+			},
+			{
+				Config: fmt.Sprintf(testGrant, `["test_column_one", "test_column_two"]`, `["UPDATE"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "objects.4260833613", "test_table"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.1759376126", "UPDATE"),
+					func(*terraform.State) error {
+						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"UPDATE"}, []string{"test_column_one"})
+					},
+					func(*terraform.State) error {
+						return testCheckColumnPrivileges(t, dbName, roleName, []string{testTables[0]}, []string{"UPDATE"}, []string{"test_column_one", "test_column_two"})
 					},
 				),
 			},
@@ -492,6 +602,67 @@ func TestAccPostgresqlGrantObjectsError(t *testing.T) {
 					privileges  = ["USAGE"]
 				}`,
 				ExpectError: regexp.MustCompile("one element must be specified in `objects` when `object_type` is `foreign_data_wrapper` or `foreign_server`"),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlGrantColumnsError(t *testing.T) {
+	skipIfNotAcc(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featurePrivileges)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "postgresql_grant" "test" {
+					database    = "test_db"
+					role        = "test_role"
+					schema      = "test_schema"
+					object_type = "column"
+					objects     = ["o1", "o2"]
+					columns     = ["col1", "col2"]
+					privileges  = ["SELECT"]
+				}`,
+				ExpectError: regexp.MustCompile("must specify exactly 1 table in the `objects` field when `object_type` is `column`"),
+			},
+			{
+				Config: `resource "postgresql_grant" "test" {
+					database    = "test_db"
+					role        = "test_role"
+					schema      = "test_schema"
+					object_type = "column"
+					objects     = ["o1"]
+					columns     = ["col1", "col2"]
+					privileges  = ["SELECT", "INSERT"]
+				}`,
+				ExpectError: regexp.MustCompile("must specify exactly 1 `privileges` when `object_type` is `column`"),
+			},
+			{
+				Config: `resource "postgresql_grant" "test" {
+					database    = "test_db"
+					role        = "test_role"
+					schema      = "test_schema"
+					object_type = "column"
+					objects     = ["o1"]
+					privileges  = ["SELECT"]
+				}`,
+				ExpectError: regexp.MustCompile("must specify `columns` when `object_type` is `column`"),
+			},
+			{
+				Config: `resource "postgresql_grant" "test" {
+					database    = "test_db"
+					role        = "test_role"
+					schema      = "test_schema"
+					object_type = "table"
+					objects     = ["o1"]
+					columns     = ["col1", "col2"]
+					privileges  = ["SELECT"]
+				}`,
+				ExpectError: regexp.MustCompile("cannot specify `columns` when `object_type` is not `column`"),
 			},
 		},
 	})

--- a/postgresql/utils_test.go
+++ b/postgresql/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -166,7 +167,7 @@ func createTestTables(t *testing.T, dbSuffix string, tables []string, owner stri
 	}
 
 	for _, table := range tables {
-		if _, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (val text)", table)); err != nil {
+		if _, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (val text, test_column_one text, test_column_two text)", table)); err != nil {
 			t.Fatalf("could not create test table in db %s: %v", dbName, err)
 		}
 		if owner != "" {
@@ -334,6 +335,36 @@ func testCheckSchemasPrivileges(t *testing.T, dbName, roleName string, schemas [
 		queries := map[string]string{
 			"USAGE":  fmt.Sprintf("DROP TABLE IF EXISTS %s.test_table", schema),
 			"CREATE": fmt.Sprintf("CREATE TABLE %s.test_table()", schema),
+		}
+
+		for queryType, query := range queries {
+			if err := testHasGrantForQuery(db, query, sliceContainsStr(allowedPrivileges, queryType)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func testCheckColumnPrivileges(t *testing.T, dbName, roleName string, tables []string, allowedPrivileges []string, columns []string) error {
+	db := connectAsTestRole(t, roleName, dbName)
+	defer db.Close()
+
+	columnValues := []string{}
+	for _, col := range columns {
+		columnValues = append(columnValues, fmt.Sprint("'", col, "'"))
+	}
+
+	updateColumnValues := []string{}
+	for i, _ := range columns {
+		updateColumnValues = append(updateColumnValues, fmt.Sprint(columns[i], " = ", columnValues[i]))
+	}
+
+	for _, table := range tables {
+		queries := map[string]string{
+			"SELECT": fmt.Sprintf("SELECT %s FROM %s", strings.Join(columns, ", "), table),
+			"INSERT": fmt.Sprintf("INSERT INTO %s(%s) VALUES (%s)", table, strings.Join(columns, ", "), strings.Join(columnValues, ", ")),
+			"UPDATE": fmt.Sprintf("UPDATE %s SET %s", table, strings.Join(updateColumnValues, ", ")),
 		}
 
 		for queryType, query := range queries {

--- a/postgresql/utils_test.go
+++ b/postgresql/utils_test.go
@@ -356,7 +356,7 @@ func testCheckColumnPrivileges(t *testing.T, dbName, roleName string, tables []s
 	}
 
 	updateColumnValues := []string{}
-	for i, _ := range columns {
+	for i := range columns {
 		updateColumnValues = append(updateColumnValues, fmt.Sprint(columns[i], " = ", columnValues[i]))
 	}
 

--- a/website/docs/r/postgresql_grant.html.markdown
+++ b/website/docs/r/postgresql_grant.html.markdown
@@ -13,10 +13,12 @@ The ``postgresql_grant`` resource creates and manages privileges given to a user
 See [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-grant.html)
 
 ~> **Note:** This resource needs Postgresql version 9 or above.
+~> **Note:** Using column & table grants on the _same_ table with the _same_ privileges can lead to unexpected behaviours.
 
 ## Usage
 
 ```hcl
+# Grant SELECT privileges on 2 tables
 resource "postgresql_grant" "readonly_tables" {
   database    = "test_db"
   role        = "test_role"
@@ -25,6 +27,17 @@ resource "postgresql_grant" "readonly_tables" {
   objects     = ["table1", "table2"]
   privileges  = ["SELECT"]
 }
+
+# Grant SELECT & INSERT privileges on 2 columns in 1 table
+resource "postgresql_grant" "read_insert_column" {
+  database    = "test_db"
+  role        = "test_role"
+  schema      = "public"
+  object_type = "column"
+  objects     = ["table1"]
+  columns     = ["col1", "col2"]
+  privileges  = ["UPDATE", "INSERT"]
+}
 ```
 
 ## Argument Reference
@@ -32,9 +45,10 @@ resource "postgresql_grant" "readonly_tables" {
 * `role` - (Required) The name of the role to grant privileges on, Set it to "public" for all roles.
 * `database` - (Required) The database to grant privileges on for this role.
 * `schema` - The database schema to grant privileges on for this role (Required except if object_type is "database")
-* `object_type` - (Required) The PostgreSQL object type to grant the privileges on (one of: database, schema, table, sequence, function, procedure, routine, foreign_data_wrapper, foreign_server).
+* `object_type` - (Required) The PostgreSQL object type to grant the privileges on (one of: database, schema, table, sequence, function, procedure, routine, foreign_data_wrapper, foreign_server, column).
 * `privileges` - (Required) The list of privileges to grant. There are different kinds of privileges: SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER, CREATE, CONNECT, TEMPORARY, EXECUTE, and USAGE. An empty list could be provided to revoke all privileges for this role.
-* `objects` - (Optional) The objects upon which to grant the privileges. An empty list (the default) means to grant permissions on *all* objects of the specified type. You cannot specify this option if the `object_type` is `database` or `schema`.
+* `objects` - (Optional) The objects upon which to grant the privileges. An empty list (the default) means to grant permissions on *all* objects of the specified type. You cannot specify this option if the `object_type` is `database` or `schema`. When `object_type` is `column`, only one value is allowed.
+* `columns` - (Optional) The columns upon which to grant the privileges. Required when `object_type` is `column`. You cannot specify this option if the `object_type` is not `column`.
 * `with_grant_option` - (Optional) Whether the recipient of these privileges can grant the same privileges to others. Defaults to false.
 
 


### PR DESCRIPTION
This PR adds the ability to manage privileges on a per column basis.

# General overview
This PR focusses on the `postgresql_grant` resources.
It adds the value `column` as a new `object_type`, along with a new argument `columns`.
It does not change the behaviour for other `object_types` in this resource.

Example:
```hcl
resource "postgresql_grant" "grant" {
  database    = "test_database"
  role        = "test_role"
  schema      = "public"
  object_type = "column" # new object_type
  objects     = ["test_table"]
  columns     = ["col1", "col2"] # new argument
  privileges  = ["UPDATE"]
}
```

To simplify the code, when `object_type` is `column`, only one `privileges` is allowed, and only one table is allowed in the `objects` argument.

# Important changes
Here are the changes to the code that were the most tricky for me to work out.

## The `readRolePrivileges` SQL statement 
We needed an SQL statement that could detect column level privileges, without those resulting from table level privileges.
We achieved this in the following way:
* Fetch all column level permissions from the `information_schema.column_privileges` table. Let's call this "A"
* Fetch table level permissions, "explode" them into rows. Let's call this "B"
* Subtract "B" from "A" to obtain only the column level permissions.

## Changing `privileges` in the `postgresql_grant` resource to `ForceNew`
Originally, the `privileges` argument did not force recreation of the resource.
This was a problem because it meant that when changing the `privileges` in a `grant` resource, the update function would be triggered and would receive only the new configuration. So the revocation would not revoke the old permissions, but the new one, which is not very useful.

Let's look at an example.
```hcl
# the base resource
resource "postgresql_grant" "example" {
...
  object_type = "column"
  objects     = ["test_table"]
  columns     = ["col1"]
  privileges  = ["UPDATE"]
}
```
We want to change the privilege to `INSERT`
```hcl
# the base resource
resource "postgresql_grant" "example" {
...
  object_type = "column"
  objects     = ["test_table"]
  columns     = ["col1"]
  privileges  = ["INSERT"]
}
```
The code would apply and work fine. However, when we'd look at the permissions in the PG DB, we could see that the `test_role` had both `INSERT` & `UPDATE` on that column.

This is because the revocation statement that ran was `REVOKE INSERT ON TABLE...` instead of `REVOKE UPDATE ON TABLE...`.

I could not find a way to fetch the privilege stored in the state, & setting the argument to `ForceNew` solved this problem. So I did that.

## Changing revoking statements for `object_type`  `table`
Previously, with `object_type` `table`, any change on the table resource meant that a revocation statement would run and revoke *all* privileges on the table before granting new ones.

This meant that, in the following configuration destroying `table_grant` would taint 'column_grant'
```hcl
resource "postgresql_grant" "table_grant" {
...
  object_type = "table"
  objects     = ["test_table"]
  privileges  = ["SELECT" ]
}
resource "postgresql_grant" "column_grant" {
...
  object_type = "column"
  objects     = ["test_table"]
  columns     = ["col1"]
  privileges  = ["INSERT"]
}
```

To prevent this, I needed to modify the revocation statements for `tables`to make them more fine grained.

# Testing 

This PR was tested thoroughly.
I added all the required test cases, and did a lot of manual testing with various scenarios to make sure everything worked as expected.
A few of the scenarios I tried:
* creating, destroying, and recreating the same column grant
* changing the privileges in a column grant resource and applying multiple times
* changing the privileges in column grant resource while having a table grant resource on the same table
* creating, destroying, and recreating the same column grant, while having a table grant resource on the same table
* creating and destroying table grants while having column grants

For each scenario, I constantly checked in the database to see what permissions were effectively available, and reran `terraform plan` to see if the `terraform refresh` were good.

I tried these scenarios on various PostgreSQL versions running in a local Docker container :
* 10.18.0
* 11.13.0
* 12.8.0
* 13.4.0

# Closing words
I'm not a Go developer & this is my first Terraform provider patch. I'm also not a PostgreSQL expert. 

I tried my best however to make a high quality PR that would benefit my organisation & hopefully others as well.

@cyrilgdn I'm available to discuss this PR in a virtual meeting if you'd like.