### PR TITLE
Fix documentation output in terraform usage.

### DIFF
--- a/website/docs/r/postgresql_replication_slot.markdown
+++ b/website/docs/r/postgresql_replication_slot.markdown
@@ -19,6 +19,7 @@ resource "postgresql_replication_slot" "my_slot" {
   name  = "my_slot"
   plugin = "test_decoding"
 }
+```
 
 ## Argument Reference
 


### PR DESCRIPTION
https://registry.terraform.io/providers/cyrilgdn/postgresql/latest/docs/resources/postgresql_replication_slot#usage doesn't visualize correctly due to missing the 3 backticks.