### PR TITLE
Add go mod vendor to linter, user correct version of go

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -15,7 +15,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
+
+      - run: go mod vendor
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2


### PR DESCRIPTION
The go lint action was broken after removing the vendor folder, this solves this.

I suspect it only worked on the last run in main due to the cache from a previous run that preserved the vendor folder.