### PR TITLE
Add function resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In order to manually run some Acceptance test locally, run the following command
 make testacc_setup 
 
 # Load the needed environment variables for the tests
-source tests/env.sh
+source tests/switch_superuser.sh
 
 # Run the test(s) that you're working on as often as you want
 TF_LOG=INFO go test -v ./postgresql -run ^TestAccPostgresqlRole_Basic$

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -34,6 +34,7 @@ const (
 	featurePrivilegesOnSchemas
 	featureForceDropDatabase
 	featurePid
+	featureFunction
 )
 
 var (
@@ -86,6 +87,9 @@ var (
 		// Column procpid was replaced by pid in pg_stat_activity
 		// for Postgresql >= 9.2 and above
 		featurePid: semver.MustParseRange(">=9.2.0"),
+
+		// We do not support CREATE FUNCTION for Postgresql < 8.4
+		featureFunction: semver.MustParseRange(">=8.4.0"),
 	}
 )
 

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -164,6 +164,7 @@ func Provider() *schema.Provider {
 			"postgresql_physical_replication_slot": resourcePostgreSQLPhysicalReplicationSlot(),
 			"postgresql_schema":                    resourcePostgreSQLSchema(),
 			"postgresql_role":                      resourcePostgreSQLRole(),
+			"postgresql_function":                  resourcePostgreSQLFunction(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/postgresql/resource_postgresql_function.go
+++ b/postgresql/resource_postgresql_function.go
@@ -1,0 +1,289 @@
+package postgresql
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/lib/pq"
+	"log"
+)
+
+const (
+	funcNameAttr        = "name"
+	funcSchemaAttr      = "schema"
+	funcBodyAttr        = "body"
+	funcArgsAttr        = "args"
+	funcDropCascadeAttr = "drop_cascade"
+
+	funcArgTypeAttr    = "type"
+	funcArgNameAttr    = "name"
+	funcArgModeAttr    = "mode"
+	funcArgDefaultAttr = "default"
+)
+
+func resourcePostgreSQLFunction() *schema.Resource {
+	return &schema.Resource{
+		Create: PGResourceFunc(resourcePostgreSQLFunctionCreate),
+		Read:   PGResourceFunc(resourcePostgreSQLFunctionRead),
+		Update: PGResourceFunc(resourcePostgreSQLFunctionUpdate),
+		Delete: PGResourceFunc(resourcePostgreSQLFunctionDelete),
+		Exists: PGResourceExistsFunc(resourcePostgreSQLFunctionExists),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			funcSchemaAttr: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Schema where the function is located. If not specified, the provider default schema is used.",
+			},
+			funcNameAttr: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the function.",
+			},
+			funcArgsAttr: {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						funcArgTypeAttr: {
+							Type:        schema.TypeString,
+							Description: "The argument type.",
+							Required:    true,
+							ForceNew:    true,
+						},
+						funcArgNameAttr: {
+							Type:        schema.TypeString,
+							Description: "The argument name. The name may be required for some languages or depending on the argument mode.",
+							Optional:    true,
+						},
+						funcArgModeAttr: {
+							Type:        schema.TypeString,
+							Description: "The argument mode. One of: IN, OUT, INOUT, or VARIADIC",
+							Optional:    true,
+							Default:     "IN",
+						},
+						funcArgDefaultAttr: {
+							Type:        schema.TypeString,
+							Description: "An expression to be used as default value if the parameter is not specified.",
+							Optional:    true,
+						},
+					},
+				},
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Function argument definitions.",
+			},
+			funcBodyAttr: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Body of the function.",
+			},
+			funcDropCascadeAttr: {
+				Type:        schema.TypeBool,
+				Description: "Automatically drop objects that depend on the function (such as operators or triggers), and in turn all objects that depend on those objects.",
+				Optional:    true,
+				Default:     false,
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLFunctionCreate(db *DBConnection, d *schema.ResourceData) error {
+	if err := createFunction(db, d, false); err != nil {
+		return err
+	}
+
+	return resourcePostgreSQLFunctionReadImpl(db, d)
+}
+
+func resourcePostgreSQLFunctionExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
+	signature := getFunctionSignature(d)
+	functionExists := false
+
+	txn, err := startTransaction(db.client, "")
+	if err != nil {
+		return false, err
+	}
+	defer deferredRollback(txn)
+
+	query := fmt.Sprintf("SELECT to_regprocedure('%s') IS NOT NULL", signature)
+	err = txn.QueryRow(query).Scan(&functionExists)
+	return functionExists, err
+}
+
+func resourcePostgreSQLFunctionRead(db *DBConnection, d *schema.ResourceData) error {
+	return resourcePostgreSQLFunctionReadImpl(db, d)
+}
+
+func resourcePostgreSQLFunctionReadImpl(db *DBConnection, d *schema.ResourceData) error {
+	signature := getFunctionSignature(d)
+
+	txn, err := startTransaction(db.client, "")
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	var funcSchema, funcName string
+
+	query := `SELECT n.nspname, p.proname ` +
+		`FROM pg_proc p ` +
+		`LEFT JOIN pg_namespace n ON p.pronamespace = n.oid ` +
+		`WHERE p.oid = to_regprocedure($1)`
+	err = txn.QueryRow(query, signature).Scan(&funcSchema, &funcName)
+	switch {
+	case err == sql.ErrNoRows:
+		log.Printf("[WARN] PostgreSQL function: %s", signature)
+		d.SetId("")
+		return nil
+	case err != nil:
+		return fmt.Errorf("Error reading function: %w", err)
+	}
+
+	d.Set(funcNameAttr, funcName)
+	d.Set(funcSchemaAttr, funcSchema)
+	d.SetId(signature)
+
+	return nil
+}
+
+func resourcePostgreSQLFunctionDelete(db *DBConnection, d *schema.ResourceData) error {
+	signature := getFunctionSignature(d)
+
+	txn, err := startTransaction(db.client, "")
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	dropMode := "RESTRICT"
+	if v, ok := d.GetOk(funcDropCascadeAttr); ok && v.(bool) {
+		dropMode = "CASCADE"
+	}
+
+	sql := fmt.Sprintf("DROP FUNCTION IF EXISTS %s %s", signature, dropMode)
+	if _, err := txn.Exec(sql); err != nil {
+		return err
+	}
+
+	if err = txn.Commit(); err != nil {
+		return fmt.Errorf("Error deleting extension: %w", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourcePostgreSQLFunctionUpdate(db *DBConnection, d *schema.ResourceData) error {
+	if err := createFunction(db, d, true); err != nil {
+		return err
+	}
+
+	return resourcePostgreSQLFunctionReadImpl(db, d)
+}
+
+func createFunction(db *DBConnection, d *schema.ResourceData, replace bool) error {
+	b := bytes.NewBufferString("CREATE ")
+
+	if replace {
+		b.WriteString(" OR REPLACE ")
+	}
+
+	b.WriteString("FUNCTION ")
+
+	if v, ok := d.GetOk(funcSchemaAttr); ok {
+		fmt.Fprint(b, pq.QuoteIdentifier(v.(string)), ".")
+	}
+
+	fmt.Fprint(b, pq.QuoteIdentifier(d.Get(funcNameAttr).(string)), " (")
+
+	if args, ok := d.GetOk(funcArgsAttr); ok {
+		args := args.([]map[string]interface{})
+
+		for i, arg := range args {
+			if i > 0 {
+				b.WriteRune(',')
+			}
+
+			b.WriteString("\n    ")
+
+			if v, ok := arg[funcArgModeAttr]; ok {
+				fmt.Fprint(b, v.(string), " ")
+			}
+
+			if v, ok := arg[funcArgNameAttr]; ok {
+				fmt.Fprint(b, v.(string), " ")
+			}
+
+			b.WriteString(arg[funcArgTypeAttr].(string))
+
+			if v, ok := arg[funcArgDefaultAttr]; ok {
+				fmt.Fprint(b, " DEFAULT ", v.(string))
+			}
+		}
+
+		if len(args) > 0 {
+			b.WriteRune('\n')
+		}
+	}
+
+	fmt.Fprint(b, ")\n", d.Get(funcBodyAttr).(string))
+
+	txn, err := startTransaction(db.client, "")
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	sql := b.String()
+	if _, err := txn.Exec(sql); err != nil {
+		return err
+	}
+
+	if err = txn.Commit(); err != nil {
+		return fmt.Errorf("Error creating extension: %w", err)
+	}
+
+	return nil
+}
+
+func getFunctionSignature(d *schema.ResourceData) string {
+	b := bytes.NewBufferString("")
+
+	if v, ok := d.GetOk(funcSchemaAttr); ok {
+		fmt.Fprint(b, pq.QuoteIdentifier(v.(string)), ".")
+	}
+
+	fmt.Fprint(b, pq.QuoteIdentifier(d.Get(funcNameAttr).(string)), "(")
+
+	if args, ok := d.GetOk(funcArgsAttr); ok {
+		argCount := 0
+
+		for _, arg := range args.([]map[string]interface{}) {
+			mode := "IN"
+
+			if v, ok := arg[funcArgModeAttr]; ok {
+				mode = v.(string)
+			}
+
+			if mode != "OUT" {
+				if argCount > 0 {
+					b.WriteRune(',')
+				}
+
+				b.WriteString(arg[funcArgTypeAttr].(string))
+				argCount += 1
+			}
+		}
+	}
+
+	b.WriteRune(')')
+
+	return b.String()
+}

--- a/postgresql/resource_postgresql_function.go
+++ b/postgresql/resource_postgresql_function.go
@@ -104,6 +104,13 @@ func resourcePostgreSQLFunction() *schema.Resource {
 }
 
 func resourcePostgreSQLFunctionCreate(db *DBConnection, d *schema.ResourceData) error {
+	if !db.featureSupported(featureFunction) {
+		return fmt.Errorf(
+			"postgresql_function resource is not supported for this Postgres version (%s)",
+			db.version,
+		)
+	}
+
 	if err := createFunction(db, d, false); err != nil {
 		return err
 	}
@@ -112,6 +119,13 @@ func resourcePostgreSQLFunctionCreate(db *DBConnection, d *schema.ResourceData) 
 }
 
 func resourcePostgreSQLFunctionExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
+	if !db.featureSupported(featureFunction) {
+		return false, fmt.Errorf(
+			"postgresql_function resource is not supported for this Postgres version (%s)",
+			db.version,
+		)
+	}
+
 	signature := getFunctionSignature(d)
 	functionExists := false
 
@@ -127,6 +141,13 @@ func resourcePostgreSQLFunctionExists(db *DBConnection, d *schema.ResourceData) 
 }
 
 func resourcePostgreSQLFunctionRead(db *DBConnection, d *schema.ResourceData) error {
+	if !db.featureSupported(featureFunction) {
+		return fmt.Errorf(
+			"postgresql_function resource is not supported for this Postgres version (%s)",
+			db.version,
+		)
+	}
+
 	return resourcePostgreSQLFunctionReadImpl(db, d)
 }
 
@@ -163,6 +184,13 @@ func resourcePostgreSQLFunctionReadImpl(db *DBConnection, d *schema.ResourceData
 }
 
 func resourcePostgreSQLFunctionDelete(db *DBConnection, d *schema.ResourceData) error {
+	if !db.featureSupported(featureFunction) {
+		return fmt.Errorf(
+			"postgresql_function resource is not supported for this Postgres version (%s)",
+			db.version,
+		)
+	}
+
 	signature := getFunctionSignature(d)
 
 	txn, err := startTransaction(db.client, "")
@@ -191,6 +219,13 @@ func resourcePostgreSQLFunctionDelete(db *DBConnection, d *schema.ResourceData) 
 }
 
 func resourcePostgreSQLFunctionUpdate(db *DBConnection, d *schema.ResourceData) error {
+	if !db.featureSupported(featureFunction) {
+		return fmt.Errorf(
+			"postgresql_function resource is not supported for this Postgres version (%s)",
+			db.version,
+		)
+	}
+
 	if err := createFunction(db, d, true); err != nil {
 		return err
 	}

--- a/postgresql/resource_postgresql_function_test.go
+++ b/postgresql/resource_postgresql_function_test.go
@@ -1,0 +1,234 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccPostgresqlFunction_Basic(t *testing.T) {
+	config := `
+resource "postgresql_function" "basic_function" {
+    name = "basic_function"
+	returns = "integer"
+    body = <<-EOF
+        AS $$
+        BEGIN
+            RETURN 1;
+        END;
+        $$ LANGUAGE plpgsql;
+    EOF
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureFunction)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlFunctionExists("postgresql_function.basic_function"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.basic_function", "name", "basic_function"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.basic_function", "schema", "public"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlFunction_MultipleArgs(t *testing.T) {
+	config := `
+resource "postgresql_schema" "test" {
+	name = "test"
+}
+
+resource "postgresql_function" "increment" {
+	schema = postgresql_schema.test.name
+    name = "increment"
+    arg {
+		name = "i"
+		type = "integer"
+		default = "7"
+	}
+    arg {
+		name = "result"
+		type = "integer"
+		mode = "OUT"
+	}
+    body = <<-EOF
+        AS $$
+        BEGIN
+            result = i + 1;
+        END;
+        $$ LANGUAGE plpgsql;
+    EOF
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureFunction)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlFunctionExists("postgresql_function.increment"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.increment", "name", "increment"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.increment", "schema", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlFunction_Update(t *testing.T) {
+	configCreate := `
+resource "postgresql_function" "func" {
+    name = "func"
+	returns = "integer"
+    body = <<-EOF
+        AS $$
+        BEGIN
+            RETURN 1;
+        END;
+        $$ LANGUAGE plpgsql;
+    EOF
+}
+`
+
+	configUpdate := `
+resource "postgresql_function" "func" {
+    name = "func"
+	returns = "integer"
+    body = <<-EOF
+        AS $$
+        BEGIN
+            RETURN 2;
+        END;
+        $$ LANGUAGE plpgsql;
+    EOF
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureFunction)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlFunctionExists("postgresql_function.func"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.func", "name", "func"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.func", "schema", "public"),
+				),
+			},
+			{
+				Config: configUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlFunctionExists("postgresql_function.func"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.func", "name", "func"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.func", "schema", "public"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPostgresqlFunctionExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		signature := rs.Primary.ID
+
+		client := testAccProvider.Meta().(*Client)
+		txn, err := startTransaction(client, "")
+		if err != nil {
+			return err
+		}
+		defer deferredRollback(txn)
+
+		exists, err := checkFunctionExists(txn, signature)
+
+		if err != nil {
+			return fmt.Errorf("Error checking function %s", err)
+		}
+
+		if !exists {
+			return fmt.Errorf("Function not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPostgresqlFunctionDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "postgresql_function" {
+			continue
+		}
+
+		txn, err := startTransaction(client, "")
+		if err != nil {
+			return err
+		}
+		defer deferredRollback(txn)
+
+		signature := rs.Primary.ID
+		exists, err := checkFunctionExists(txn, signature)
+
+		if err != nil {
+			return fmt.Errorf("Error checking function %s", err)
+		}
+
+		if exists {
+			return fmt.Errorf("Function still exists after destroy")
+		}
+	}
+
+	return nil
+}
+
+func checkFunctionExists(txn *sql.Tx, signature string) (bool, error) {
+	var _rez bool
+	err := txn.QueryRow(fmt.Sprintf("SELECT to_regprocedure('%s') IS NOT NULL", signature)).Scan(&_rez)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("Error reading info about function: %s", err)
+	}
+
+	return _rez, nil
+}

--- a/website/docs/r/postgresql_function.html.markdown
+++ b/website/docs/r/postgresql_function.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "postgresql"
+page_title: "PostgreSQL: postgresql_function"
+sidebar_current: "docs-postgresql-resource-postgresql_function"
+description: |-
+Creates and manages a function on a PostgreSQL server.
+---
+
+# postgresql\_function
+
+The ``postgresql_function`` resource creates and manages a function on a PostgreSQL
+server.
+
+## Usage
+
+```hcl
+resource "postgresql_function" "increment" {
+    name = "increment"
+    args = [
+        {
+            name = "i"
+            type = "integer"
+        }
+    ]
+    returns = "integer"
+    body = <<-EOF
+        AS $$
+        BEGIN
+            RETURN i + 1;
+        END;
+        $$ LANGUAGE plpgsql;
+    EOF
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the function.
+
+* `schema` - (Optional) The schema where the function is located.
+  If not specified, the function is created in the current schema.
+
+* `args` - (Optional) List of arguments for the function.
+
+* `returns` - (Optional) Type that the function returns.
+
+* `body` - (Required) Function body.
+  This should be everything after the return type in the function definition.
+
+* `drop_cascade` - (Optional) True to automatically drop objects that depend on the function (such as 
+  operators or triggers), and in turn all objects that depend on those objects.
+
+The `args` list element:
+
+* `type` - (Required) The type of the argument.
+
+* `name` - (Optional) The name of the argument.
+
+* `mode` - (Optional) Can be one of IN, INOUT, OUT, or VARIADIC. Default is IN.
+
+* `default` - (Optional) An expression to be used as default value if the parameter is not specified.

--- a/website/docs/r/postgresql_function.html.markdown
+++ b/website/docs/r/postgresql_function.html.markdown
@@ -50,4 +50,4 @@ resource "postgresql_function" "increment" {
   This should be everything after the return type in the function definition.
 
 * `drop_cascade` - (Optional) True to automatically drop objects that depend on the function (such as 
-  operators or triggers), and in turn all objects that depend on those objects.
+  operators or triggers), and in turn all objects that depend on those objects. Default is false.

--- a/website/docs/r/postgresql_function.html.markdown
+++ b/website/docs/r/postgresql_function.html.markdown
@@ -16,12 +16,10 @@ server.
 ```hcl
 resource "postgresql_function" "increment" {
     name = "increment"
-    args = [
-        {
-            name = "i"
-            type = "integer"
-        }
-    ]
+    arg {
+        name = "i"
+        type = "integer"
+    }
     returns = "integer"
     body = <<-EOF
         AS $$
@@ -40,7 +38,11 @@ resource "postgresql_function" "increment" {
 * `schema` - (Optional) The schema where the function is located.
   If not specified, the function is created in the current schema.
 
-* `args` - (Optional) List of arguments for the function.
+* `arg` - (Optional) List of arguments for the function.
+  * `type` - (Required) The type of the argument.
+  * `name` - (Optional) The name of the argument.
+  * `mode` - (Optional) Can be one of IN, INOUT, OUT, or VARIADIC. Default is IN.
+  * `default` - (Optional) An expression to be used as default value if the parameter is not specified.
 
 * `returns` - (Optional) Type that the function returns.
 
@@ -49,13 +51,3 @@ resource "postgresql_function" "increment" {
 
 * `drop_cascade` - (Optional) True to automatically drop objects that depend on the function (such as 
   operators or triggers), and in turn all objects that depend on those objects.
-
-The `args` list element:
-
-* `type` - (Required) The type of the argument.
-
-* `name` - (Optional) The name of the argument.
-
-* `mode` - (Optional) Can be one of IN, INOUT, OUT, or VARIADIC. Default is IN.
-
-* `default` - (Optional) An expression to be used as default value if the parameter is not specified.

--- a/website/docs/r/postgresql_physical_replication_slot.markdown
+++ b/website/docs/r/postgresql_physical_replication_slot.markdown
@@ -19,6 +19,7 @@ any stand-by cluster to replicate physically data.
 resource "postgresql_physical_replication_slot" "my_slot" {
   name  = "my_slot"
 }
+```
 
 ## Argument Reference
 

--- a/website/postgresql.erb
+++ b/website/postgresql.erb
@@ -37,6 +37,9 @@
                     <li<%= sidebar_current("docs-postgresql-resource-postgresql_schema") %>>
                         <a href="/docs/providers/postgresql/r/postgresql_schema.html">postgresql_schema</a>
                     </li>
+                    <li<%= sidebar_current("docs-postgresql-resource-postgresql_function") %>>
+                        <a href="/docs/providers/postgresql/r/postgresql_function.html">postgresql_function</a>
+                    </li>
                 </ul>
         </li>
       </ul>


### PR DESCRIPTION
The use case for this resource is setting up datadog agent access. It requires defining a `datadog.explain_statement` function that the dd agent expects to exist. I can setup everything in terraform except for the required function.

https://docs.datadoghq.com/database_monitoring/setup_postgres/aurora/?tab=postgres10