### PR TITLE
Add database parameter on function resource 

### DIFF
--- a/postgresql/resource_postgresql_function_test.go
+++ b/postgresql/resource_postgresql_function_test.go
@@ -47,6 +47,8 @@ resource "postgresql_function" "basic_function" {
 }
 
 func TestAccPostgresqlFunction_SpecificDatabase(t *testing.T) {
+	skipIfNotAcc(t)
+
 	dbSuffix, teardown := setupTestDatabase(t, true, true)
 	defer teardown()
 

--- a/postgresql/resource_postgresql_function_test.go
+++ b/postgresql/resource_postgresql_function_test.go
@@ -35,9 +35,54 @@ resource "postgresql_function" "basic_function" {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlFunctionExists("postgresql_function.basic_function"),
+					testAccCheckPostgresqlFunctionExists("postgresql_function.basic_function", ""),
 					resource.TestCheckResourceAttr(
 						"postgresql_function.basic_function", "name", "basic_function"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.basic_function", "schema", "public"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlFunction_SpecificDatabase(t *testing.T) {
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+
+	dbName, _ := getTestDBNames(dbSuffix)
+
+	config := `
+resource "postgresql_function" "basic_function" {
+    name = "basic_function"
+	database = "%s"
+	returns = "integer"
+    body = <<-EOF
+        AS $$
+        BEGIN
+            RETURN 1;
+        END;
+        $$ LANGUAGE plpgsql;
+    EOF
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureFunction)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(config, dbName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlFunctionExists("postgresql_function.basic_function", dbName),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.basic_function", "name", "basic_function"),
+					resource.TestCheckResourceAttr(
+						"postgresql_function.basic_function", "database", dbName),
 					resource.TestCheckResourceAttr(
 						"postgresql_function.basic_function", "schema", "public"),
 				),
@@ -86,7 +131,7 @@ resource "postgresql_function" "increment" {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlFunctionExists("postgresql_function.increment"),
+					testAccCheckPostgresqlFunctionExists("postgresql_function.increment", ""),
 					resource.TestCheckResourceAttr(
 						"postgresql_function.increment", "name", "increment"),
 					resource.TestCheckResourceAttr(
@@ -136,7 +181,7 @@ resource "postgresql_function" "func" {
 			{
 				Config: configCreate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlFunctionExists("postgresql_function.func"),
+					testAccCheckPostgresqlFunctionExists("postgresql_function.func", ""),
 					resource.TestCheckResourceAttr(
 						"postgresql_function.func", "name", "func"),
 					resource.TestCheckResourceAttr(
@@ -146,7 +191,7 @@ resource "postgresql_function" "func" {
 			{
 				Config: configUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlFunctionExists("postgresql_function.func"),
+					testAccCheckPostgresqlFunctionExists("postgresql_function.func", ""),
 					resource.TestCheckResourceAttr(
 						"postgresql_function.func", "name", "func"),
 					resource.TestCheckResourceAttr(
@@ -157,7 +202,7 @@ resource "postgresql_function" "func" {
 	})
 }
 
-func testAccCheckPostgresqlFunctionExists(n string) resource.TestCheckFunc {
+func testAccCheckPostgresqlFunctionExists(n string, database string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -171,7 +216,7 @@ func testAccCheckPostgresqlFunctionExists(n string) resource.TestCheckFunc {
 		signature := rs.Primary.ID
 
 		client := testAccProvider.Meta().(*Client)
-		txn, err := startTransaction(client, "")
+		txn, err := startTransaction(client, database)
 		if err != nil {
 			return err
 		}

--- a/website/docs/r/postgresql_function.html.markdown
+++ b/website/docs/r/postgresql_function.html.markdown
@@ -38,6 +38,9 @@ resource "postgresql_function" "increment" {
 * `schema` - (Optional) The schema where the function is located.
   If not specified, the function is created in the current schema.
 
+* `database` - (Optional) The database where the function is located.
+  If not specified, the function is created in the current database.
+
 * `arg` - (Optional) List of arguments for the function.
   * `type` - (Required) The type of the argument.
   * `name` - (Optional) The name of the argument.


### PR DESCRIPTION
## Overview
This allows specifying database when creating a function.

## Actual behavior
When creating a function is always created in the provider's database.