### PR TITLE
Add roleDisableLogsAttr to prevent password leakage in logs

### DIFF
--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -35,6 +35,7 @@ const (
 	roleSearchPathAttr                      = "search_path"
 	roleStatementTimeoutAttr                = "statement_timeout"
 	roleAssumeRoleAttr                      = "assume_role"
+	roleDisableLogsAttr                     = "disable_logs"
 
 	// Deprecated options
 	roleDepEncryptedAttr = "encrypted"
@@ -173,6 +174,12 @@ func resourcePostgreSQLRole() *schema.Resource {
 				Optional:    true,
 				Description: "Role to switch to at login",
 			},
+			roleDisableLogsAttr: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Disables logs to prevent passwords from leaking",
+			},
 		},
 	}
 }
@@ -286,6 +293,15 @@ func resourcePostgreSQLRoleCreate(db *DBConnection, d *schema.ResourceData) erro
 		}
 	}
 
+	areLogsDisabled := d.Get(roleDisableLogsAttr).(bool)
+	if areLogsDisabled {
+		sql := "SET log_statement TO 'none'; SET log_min_duration_statement TO -1; SET log_min_error_statement TO 'log'; SET pg_stat_statements.track_utility = 'off';"
+
+		if _, err := txn.Exec(sql); err != nil {
+			return fmt.Errorf("could not disable logs for %s: %w", roleName, err)
+		}
+	}
+
 	sql := fmt.Sprintf("CREATE ROLE %s%s", pq.QuoteIdentifier(roleName), createStr)
 	if _, err := txn.Exec(sql); err != nil {
 		return fmt.Errorf("error creating role %s: %w", roleName, err)
@@ -381,7 +397,7 @@ func resourcePostgreSQLRoleRead(db *DBConnection, d *schema.ResourceData) error 
 }
 
 func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) error {
-	var roleSuperuser, roleInherit, roleCreateRole, roleCreateDB, roleCanLogin, roleReplication, roleBypassRLS bool
+	var roleSuperuser, roleInherit, roleCreateRole, roleCreateDB, roleCanLogin, roleReplication, roleBypassRLS, roleDisableLogs bool
 	var roleConnLimit int
 	var roleName, roleValidUntil string
 	var roleRoles, roleConfig pq.ByteaArray
@@ -457,6 +473,7 @@ func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) er
 	d.Set(roleRolesAttr, pgArrayToSet(roleRoles))
 	d.Set(roleSearchPathAttr, readSearchPath(roleConfig))
 	d.Set(roleAssumeRoleAttr, readAssumeRole(roleConfig))
+	d.Set(roleDisableLogsAttr, roleDisableLogs)
 
 	statementTimeout, err := readStatementTimeout(roleConfig)
 	if err != nil {

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -33,10 +33,11 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					testAccCheckPostgresqlRoleExists("role_default", nil, nil),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "name", "role_default"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "superuser", "false"),
-					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "create_database", "false"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "create_database", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "create_role", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "inherit", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "replication", "false"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "disable_logs", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "bypass_row_level_security", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "connection_limit", "-1"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "encrypted_password", "true"),
@@ -115,6 +116,7 @@ resource "postgresql_role" "group_role" {
 resource "postgresql_role" "update_role" {
   name = "update_role2"
   login = true
+  disable_logs = false
   connection_limit = 5
   password = "titi"
   roles = ["${postgresql_role.group_role.name}"]
@@ -146,6 +148,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "disable_logs", "true"),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -167,6 +170,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "30000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "60000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", "group_role"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "login", "false"),
 					testAccCheckRoleCanLogin(t, "update_role2", "titi"),
 				),
 			},
@@ -185,6 +189,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "disable_logs", "true"),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -418,6 +423,7 @@ resource "postgresql_role" "role_with_defaults" {
   statement_timeout = 0
   idle_in_transaction_session_timeout = 0
   assume_role = ""
+  disable_logs = false
 }
 
 resource "postgresql_role" "role_with_create_database" {
@@ -437,4 +443,10 @@ resource "postgresql_role" "role_with_search_path" {
   name = "role_with_search_path"
   search_path = ["bar", "foo-with-hyphen"]
 }
+resource "postgresql_role" "role_with_log_enabled" {
+	name = "role_with_log_enabled"
+	login = true
+	password = "mypass"
+	disable_logs = false
+  }
 `


### PR DESCRIPTION
Currently, when a new role is created, the logs output the password
`2022-07-25 18:53:15.069 UTC [49] LOG:  statement: CREATE ROLE "my_role" WITH ENCRYPTED PASSWORD 'mypass' VALID UNTIL 'infinity' CONNECTION LIMIT -1 NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN NOBYPASSRLS NOREPLICATION`

This new attribute, disable_logs, allows the user to determine whether or not they want the logs of any roles being created to be included or skipped, as shown below.

```
2022-07-25 18:55:13.616 UTC [51] LOG:  statement: CREATE ROLE "role_with_logs" WITH ENCRYPTED PASSWORD 'mypass' VALID UNTIL 'infinity' CONNECTION LIMIT -1 NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN NOBYPASSRLS NOREPLICATION

2022-07-25 18:55:13.632 UTC [53] DETAIL:  parameters: $1 = 'role_with_logs'

2022-07-25 18:55:13.645 UTC [56] DETAIL:  parameters: $1 = 'role_with_no_logs'
```



The attribute is defaulted to `true` for improved security.  For those who want to enable these logs, when defining a new role, include `disable_logs = false` besides the other included attributes.

```
resource "postgresql_role" "role_with_logs" {
    name         = "role_with_logs"
    login        = true
    password     = "mypass"
    disable_logs = false
}
```


