### PR TITLE
 Add roleEnableLogsAttr to prevent password leakage in logs 

### DIFF
--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -37,6 +37,7 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "create_role", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "inherit", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "replication", "false"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "enable_logs", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "bypass_row_level_security", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "connection_limit", "-1"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "encrypted_password", "true"),
@@ -115,6 +116,7 @@ resource "postgresql_role" "group_role" {
 resource "postgresql_role" "update_role" {
   name = "update_role2"
   login = true
+  enable_logs = false
   connection_limit = 5
   password = "titi"
   roles = ["${postgresql_role.group_role.name}"]
@@ -146,6 +148,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "enable_logs", "false"),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -167,6 +170,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "30000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "60000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", "group_role"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "enable_logs", "false"),
 					testAccCheckRoleCanLogin(t, "update_role2", "titi"),
 				),
 			},
@@ -185,6 +189,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "enable_logs", "false"),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -418,6 +423,7 @@ resource "postgresql_role" "role_with_defaults" {
   statement_timeout = 0
   idle_in_transaction_session_timeout = 0
   assume_role = ""
+  enable_logs = false
 }
 
 resource "postgresql_role" "role_with_create_database" {
@@ -437,4 +443,11 @@ resource "postgresql_role" "role_with_search_path" {
   name = "role_with_search_path"
   search_path = ["bar", "foo-with-hyphen"]
 }
+
+resource "postgresql_role" "role_with_log_enabled" {
+	name = "role_with_log_enabled"
+	login = true
+	password = "mypass"
+	enable_logs = false
+  }
 `


### PR DESCRIPTION
Currently, when a new role is created, the logs output the password
`2022-07-25 18:53:15.069 UTC [49] LOG: statement: CREATE ROLE "my_role" WITH ENCRYPTED PASSWORD 'mypass' VALID UNTIL 'infinity' CONNECTION LIMIT -1 NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN NOBYPASSRLS NOREPLICATION`

This new attribute, `enable_logs`, allows the user to determine whether or not they want the logs of any roles being created to be included or skipped, as shown below.

```
2022-07-25 18:55:13.616 UTC [51] LOG:  statement: CREATE ROLE "role_with_logs" WITH ENCRYPTED PASSWORD 'mypass' VALID UNTIL 'infinity' CONNECTION LIMIT -1 NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN NOBYPASSRLS NOREPLICATION

2022-07-25 18:55:13.632 UTC [53] DETAIL:  parameters: $1 = 'role_with_logs'

2022-07-25 18:55:13.645 UTC [56] DETAIL:  parameters: $1 = 'role_with_no_logs'
```
The attribute is defaulted to `false` for improved security. For those who want to enable these logs, when defining a new role, include `enable_logs = true` besides the other included attributes.

```
resource "postgresql_role" "role_with_logs" {
    name         = "role_with_logs"
    login        = true
    password     = "mypass"
    enable_logs = true
}
```