### PR TITLE
postgresql_grant: Remove TEMP privilege for database

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -235,7 +235,7 @@ func sliceContainsStr(haystack []string, needle string) bool {
 // allowedPrivileges is the list of privileges allowed per object types in Postgres.
 // see: https://www.postgresql.org/docs/current/sql-grant.html
 var allowedPrivileges = map[string][]string{
-	"database":             {"ALL", "CREATE", "CONNECT", "TEMPORARY", "TEMP"},
+	"database":             {"ALL", "CREATE", "CONNECT", "TEMPORARY"},
 	"table":                {"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"},
 	"sequence":             {"ALL", "USAGE", "SELECT", "UPDATE"},
 	"schema":               {"ALL", "CREATE", "USAGE"},


### PR DESCRIPTION
It's an alternative spelling for `TEMPORARY`. In pg_database, only `TEMPORARY` is saved so let's remove `TEMP` to keep the code simple and not having to manage this specific use case.

closes #222