### PR TITLE
postgresql_default_privileges: Fix `object_type` documentation

### DIFF
--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -56,7 +56,7 @@ func resourcePostgreSQLDefaultPrivileges() *schema.Resource {
 					"type",
 					"schema",
 				}, false),
-				Description: "The PostgreSQL object type to set the default privileges on (one of: table, sequence, function, type)",
+				Description: "The PostgreSQL object type to set the default privileges on (one of: table, sequence, function, type, schema)",
 			},
 			"privileges": {
 				Type:        schema.TypeSet,

--- a/website/docs/r/postgresql_default_privileges.html.markdown
+++ b/website/docs/r/postgresql_default_privileges.html.markdown
@@ -32,7 +32,7 @@ resource "postgresql_default_privileges" "read_only_tables" {
 * `database` - (Required) The database to grant default privileges for this role.
 * `owner` - (Required) Role for which apply default privileges (You can change default privileges only for objects that will be created by yourself or by roles that you are a member of).
 * `schema` - (Optional) The database schema to set default privileges for this role.
-* `object_type` - (Required) The PostgreSQL object type to set the default privileges on (one of: table, sequence, function, type).
+* `object_type` - (Required) The PostgreSQL object type to set the default privileges on (one of: table, sequence, function, type, schema).
 * `privileges` - (Required) The list of privileges to apply as default privileges. An empty list could be provided to revoke all default privileges for this role.
 
 


### PR DESCRIPTION
Hi, thank you so much for great terraform provider.

I look that the argument “object_type” of postgresql_default_previledges resource supports a value “schema” but it doesn’t be described on a document.

I modified it so could you confirm my pull request?

Thank you.