### PR TITLE
fix postgresql_user_mapping on AWS RDS Aurora

### DIFF
--- a/postgresql/resource_postgresql_user_mapping.go
+++ b/postgresql/resource_postgresql_user_mapping.go
@@ -112,7 +112,7 @@ func resourcePostgreSQLUserMappingReadImpl(db *DBConnection, d *schema.ResourceD
 	defer deferredRollback(txn)
 
 	var userMappingOptions []string
-	query := "SELECT umoptions FROM pg_user_mappings WHERE usename = $1 and srvname = $2"
+	query := "SELECT umoptions FROM information_schema._pg_user_mappings WHERE authorization_identifier = $1 and foreign_server_name = $2"
 	err = txn.QueryRow(query, username, serverName).Scan(pq.Array(&userMappingOptions))
 	switch {
 	case err == sql.ErrNoRows:

--- a/postgresql/resource_postgresql_user_mapping.go
+++ b/postgresql/resource_postgresql_user_mapping.go
@@ -125,8 +125,8 @@ func resourcePostgreSQLUserMappingReadImpl(db *DBConnection, d *schema.ResourceD
 
 	mappedOptions := make(map[string]interface{})
 	for _, v := range userMappingOptions {
-		pair := strings.Split(v, "=")
-		mappedOptions[pair[0]] = pair[1]
+		idx := strings.Index(v, "=")
+		mappedOptions[v[:idx]] = v[idx+1:]
 	}
 
 	d.Set(userMappingUserNameAttr, username)

--- a/postgresql/resource_postgresql_user_mapping.go
+++ b/postgresql/resource_postgresql_user_mapping.go
@@ -125,8 +125,8 @@ func resourcePostgreSQLUserMappingReadImpl(db *DBConnection, d *schema.ResourceD
 
 	mappedOptions := make(map[string]interface{})
 	for _, v := range userMappingOptions {
-		idx := strings.Index(v, "=")
-		mappedOptions[v[:idx]] = v[idx+1:]
+		pair := strings.SplitN(v, "=", 2)
+		mappedOptions[pair[0]] = pair[1]
 	}
 
 	d.Set(userMappingUserNameAttr, username)

--- a/postgresql/resource_postgresql_user_mapping_test.go
+++ b/postgresql/resource_postgresql_user_mapping_test.go
@@ -32,6 +32,8 @@ func TestAccPostgresqlUserMapping_Basic(t *testing.T) {
 						"postgresql_user_mapping.remote", "options.user", "admin"),
 					resource.TestCheckResourceAttr(
 						"postgresql_user_mapping.remote", "options.password", "pass"),
+					resource.TestCheckResourceAttr(
+						"postgresql_user_mapping.special_chars", "options.password", "pass=$*'"),
 				),
 			},
 		},
@@ -189,6 +191,19 @@ resource "postgresql_user_mapping" "remote" {
   options = {
     user = "admin"
     password = "pass"
+  }
+}
+
+resource "postgresql_role" "special" {
+  name = "special"
+}
+
+resource "postgresql_user_mapping" "special_chars" {
+  server_name = postgresql_server.myserver_postgres.server_name
+  user_name   = postgresql_role.special.name
+  options = {
+	user = "admin"
+	password = "pass=$*'"
   }
 }
 `


### PR DESCRIPTION
AWS RDS Aurora doesn't allow reading user_mappings from pg_catalog.pg_user_mappings but allows from information_schema._pg_user_mappings, which contains the same information. 
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.Extensions.foreign-data-wrappers.html#postgresql-oracle-fdw.permissions

I also found another bug when the password contains `=` in it, so I changed the way it's mapping the options


fix #280 