### PR TITLE
feat: add function import support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,10 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.15.0
 	github.com/lib/pq v1.10.4
 	github.com/sean-/postgresql-acl v0.0.0-20161225120419-d10489e5d217
+	github.com/stretchr/testify v1.7.0
 	gocloud.dev v0.25.0
 	golang.org/x/net v0.0.0-20220401154927-543a649e0bdd
+	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a
 )
 
 require (
@@ -63,6 +65,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
@@ -72,7 +75,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
-	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
 	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
@@ -81,4 +83,5 @@ require (
 	google.golang.org/genproto v0.0.0-20220401170504-314d38edb7de // indirect
 	google.golang.org/grpc v1.45.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -534,8 +534,5 @@ func findStringSubmatchMap(expression string, text string) map[string]string {
 }
 
 func defaultDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	if old == new {
-		return true
-	}
-	return false
+	return old == new
 }

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -514,4 +515,27 @@ func isUniqueArr(arr []interface{}) (interface{}, bool) {
 		keys[entry] = true
 	}
 	return nil, true
+}
+
+func findStringSubmatchMap(expression string, text string) map[string]string {
+
+	r := regexp.MustCompile(expression)
+
+	parts := r.FindStringSubmatch(text)
+
+	paramsMap := make(map[string]string)
+	for i, name := range r.SubexpNames() {
+		if i > 0 && i <= len(parts) {
+			paramsMap[name] = parts[i]
+		}
+	}
+
+	return paramsMap
+}
+
+func defaultDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if old == new {
+		return true
+	}
+	return false
 }

--- a/postgresql/helpers_test.go
+++ b/postgresql/helpers_test.go
@@ -1,0 +1,19 @@
+package postgresql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindStringSubmatchMap(t *testing.T) {
+
+	resultMap := findStringSubmatchMap(`(?si).*\$(?P<Body>.*)\$.*`, "aa $somehing_to_extract$ bb")
+
+	assert.Equal(t,
+		resultMap,
+		map[string]string{
+			"Body": "somehing_to_extract",
+		},
+	)
+}

--- a/postgresql/model_pg_function.go
+++ b/postgresql/model_pg_function.go
@@ -99,7 +99,10 @@ func (pgFunction *PGFunction) Parse(functionDefinition string) error {
 		rawArgs := strings.Split(argsData, ",")
 		for i := 0; i < len(rawArgs); i++ {
 			var arg PGFunctionArg
-			arg.Parse(rawArgs[i])
+			err := arg.Parse(rawArgs[i])
+			if err != nil {
+				continue
+			}
 			args = append(args, arg)
 		}
 	}

--- a/postgresql/model_pg_function.go
+++ b/postgresql/model_pg_function.go
@@ -1,0 +1,145 @@
+package postgresql
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// PGFunction is the model for the database function
+type PGFunction struct {
+	Schema   string
+	Name     string
+	Returns  string
+	Language string
+	Body     string
+	Args     []PGFunctionArg
+}
+
+type PGFunctionArg struct {
+	Name    string
+	Type    string
+	Mode    string
+	Default string
+}
+
+func (pgFunction *PGFunction) FromResourceData(d *schema.ResourceData) error {
+
+	if v, ok := d.GetOk(funcSchemaAttr); ok {
+		pgFunction.Schema = v.(string)
+	} else {
+		pgFunction.Schema = "public"
+	}
+
+	pgFunction.Name = d.Get(funcNameAttr).(string)
+	pgFunction.Returns = d.Get(funcReturnsAttr).(string)
+	if v, ok := d.GetOk(funcLanguageAttr); ok {
+		pgFunction.Language = v.(string)
+	} else {
+		pgFunction.Language = "plpgsql"
+	}
+	pgFunction.Body = normalizeFunctionBody(d.Get(funcBodyAttr).(string))
+	pgFunction.Args = []PGFunctionArg{}
+
+	// For the main returns if not provided
+	argOutput := "void"
+
+	if args, ok := d.GetOk(funcArgAttr); ok {
+		args := args.([]interface{})
+
+		for _, arg := range args {
+			arg := arg.(map[string]interface{})
+
+			var pgArg PGFunctionArg
+
+			if v, ok := arg[funcArgModeAttr]; ok {
+				pgArg.Mode = v.(string)
+			}
+
+			if v, ok := arg[funcArgNameAttr]; ok {
+				pgArg.Name = v.(string)
+			}
+
+			pgArg.Type = arg[funcArgTypeAttr].(string)
+
+			if v, ok := arg[funcArgDefaultAttr]; ok {
+				pgArg.Default = v.(string)
+			}
+
+			// For the main returns if not provided
+			if strings.ToUpper(pgArg.Mode) == "OUT" {
+				argOutput = pgArg.Type
+			}
+
+			pgFunction.Args = append(pgFunction.Args, pgArg)
+		}
+	}
+
+	if v, ok := d.GetOk(funcReturnsAttr); ok {
+		pgFunction.Returns = v.(string)
+	} else {
+		pgFunction.Returns = argOutput
+	}
+
+	return nil
+}
+
+func (pgFunction *PGFunction) Parse(functionDefinition string) error {
+
+	pgFunctionData := findStringSubmatchMap(
+		`(?si)CREATE\sOR\sREPLACE\sFUNCTION\s(?P<Schema>[^.]+)\.(?P<Name>[^(]+)\((?P<Args>.*)\).*RETURNS\s(?P<Returns>[^\n]+).*LANGUAGE\s(?P<Language>[^\n]+).*\$[a-zA-Z]*\$(?P<Body>.*)\$[a-zA-Z]*\$`,
+		functionDefinition,
+	)
+
+	argsData := pgFunctionData["Args"]
+
+	args := []PGFunctionArg{}
+
+	if argsData != "" {
+		rawArgs := strings.Split(argsData, ",")
+		for i := 0; i < len(rawArgs); i++ {
+			var arg PGFunctionArg
+			arg.Parse(rawArgs[i])
+			args = append(args, arg)
+		}
+	}
+
+	pgFunction.Schema = pgFunctionData["Schema"]
+	pgFunction.Name = pgFunctionData["Name"]
+	pgFunction.Returns = pgFunctionData["Returns"]
+	pgFunction.Language = pgFunctionData["Language"]
+	pgFunction.Body = pgFunctionData["Body"]
+	pgFunction.Args = args
+
+	return nil
+}
+
+func (pgFunctionArg *PGFunctionArg) Parse(functionArgDefinition string) error {
+
+	// Check if default exists
+	argDefinitions := findStringSubmatchMap(`(?si)(?P<ArgData>.*)\sDEFAULT\s(?P<ArgDefault>.*)`, functionArgDefinition)
+
+	argData := functionArgDefinition
+	if len(argDefinitions) > 0 {
+		argData = argDefinitions["ArgData"]
+		pgFunctionArg.Default = argDefinitions["ArgDefault"]
+	}
+
+	pgFunctionArgData := findStringSubmatchMap(`(?si)((?P<Mode>IN|OUT|INOUT|VARIADIC)\s)?(?P<Name>[^\s]+)\s(?P<Type>.*)`, argData)
+
+	pgFunctionArg.Name = pgFunctionArgData["Name"]
+	pgFunctionArg.Type = pgFunctionArgData["Type"]
+	pgFunctionArg.Mode = pgFunctionArgData["Mode"]
+	if pgFunctionArg.Mode == "" {
+		pgFunctionArg.Mode = "IN"
+	}
+	return nil
+}
+
+func normalizeFunctionBody(body string) string {
+	newBodyMap := findStringSubmatchMap(`(?si).*\$[a-zA-Z]*\$\s(?P<Body>.*)\s\$[a-zA-Z]*\$.*`, body)
+	if newBody, ok := newBodyMap["Body"]; ok {
+		return newBody
+	}
+	return body
+}

--- a/postgresql/model_pg_function_test.go
+++ b/postgresql/model_pg_function_test.go
@@ -1,0 +1,205 @@
+package postgresql
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromResourceData(t *testing.T) {
+	d := mockFunctionResourceData(t, PGFunction{
+		Name: "increment",
+		Body: "BEGIN result = i + 1; END;",
+		Args: []PGFunctionArg{
+			{
+				Name: "i",
+				Type: "integer",
+			},
+			{
+				Name: "result",
+				Type: "integer",
+				Mode: "OUT",
+			},
+		},
+	})
+
+	var pgFunction PGFunction
+
+	err := pgFunction.FromResourceData(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, pgFunction, PGFunction{
+		Schema:   "public",
+		Name:     "increment",
+		Returns:  "integer",
+		Language: "plpgsql",
+		Body:     "BEGIN result = i + 1; END;",
+		Args: []PGFunctionArg{
+			{
+				Name: "i",
+				Type: "integer",
+			},
+			{
+				Name: "result",
+				Type: "integer",
+				Mode: "OUT",
+			},
+		},
+	})
+}
+
+func TestPGFunctionParseWithArguments(t *testing.T) {
+
+	var functionDefinition = `
+CREATE OR REPLACE FUNCTION public.pg_func_test(showtext boolean, OUT userid oid, default_null integer DEFAULT NULL::integer, simple_default integer DEFAULT 42, long_default character varying DEFAULT 'foo'::character varying)
+RETURNS SETOF record
+LANGUAGE c
+PARALLEL SAFE STRICT
+AS $function$pg_func_test_body$function$
+	`
+
+	var pgFunction PGFunction
+
+	err := pgFunction.Parse(functionDefinition)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, pgFunction, PGFunction{
+		Name:     "pg_func_test",
+		Schema:   "public",
+		Returns:  "SETOF record",
+		Language: "c",
+		Body:     "pg_func_test_body",
+		Args: []PGFunctionArg{
+			{
+				Mode: "IN",
+				Name: "showtext",
+				Type: "boolean",
+			},
+			{
+				Mode: "OUT",
+				Name: "userid",
+				Type: "oid",
+			},
+			{
+				Mode:    "IN",
+				Name:    "default_null",
+				Type:    "integer",
+				Default: "NULL::integer",
+			},
+			{
+				Mode:    "IN",
+				Name:    "simple_default",
+				Type:    "integer",
+				Default: "42",
+			},
+			{
+				Mode:    "IN",
+				Name:    "long_default",
+				Type:    "character varying",
+				Default: "'foo'::character varying",
+			},
+		},
+	})
+}
+
+func TestPGFunctionParseWithoutArguments(t *testing.T) {
+
+	var functionDefinition = `
+CREATE OR REPLACE FUNCTION public.pg_func_test()
+RETURNS SETOF record
+LANGUAGE plpgsql
+PARALLEL SAFE STRICT
+AS $function$
+MultiLine Function
+$function$
+	`
+
+	var pgFunction PGFunction
+
+	err := pgFunction.Parse(functionDefinition)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, pgFunction, PGFunction{
+		Name:     "pg_func_test",
+		Schema:   "public",
+		Returns:  "SETOF record",
+		Language: "plpgsql",
+		Body: `
+MultiLine Function
+`,
+		Args: []PGFunctionArg{},
+	})
+}
+
+func TestPGFunctionArgParseWithDefault(t *testing.T) {
+
+	var functionArgDefinition = `default_null integer DEFAULT NULL::integer`
+
+	var pgFunctionArg PGFunctionArg
+
+	err := pgFunctionArg.Parse(functionArgDefinition)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, pgFunctionArg, PGFunctionArg{
+		Mode:    "IN",
+		Name:    "default_null",
+		Type:    "integer",
+		Default: "NULL::integer",
+	})
+}
+
+func TestPGFunctionArgParseWithoutDefault(t *testing.T) {
+
+	var functionArgDefinition = `num integer`
+
+	var pgFunctionArg PGFunctionArg
+
+	err := pgFunctionArg.Parse(functionArgDefinition)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, pgFunctionArg, PGFunctionArg{
+		Mode: "IN",
+		Name: "num",
+		Type: "integer",
+	})
+}
+
+func mockFunctionResourceData(t *testing.T, obj PGFunction) *schema.ResourceData {
+
+	state := terraform.InstanceState{}
+
+	state.ID = ""
+	// Build the attribute map from ForemanModel
+	attributes := make(map[string]interface{})
+
+	attributes["name"] = obj.Name
+	attributes["returns"] = obj.Returns
+	attributes["language"] = obj.Language
+	attributes["body"] = obj.Body
+
+	var args []interface{}
+
+	for _, a := range obj.Args {
+		args = append(args, map[string]interface{}{
+			"type":    a.Type,
+			"name":    a.Name,
+			"mode":    a.Mode,
+			"default": a.Default,
+		})
+	}
+
+	attributes["arg"] = args
+
+	return schema.TestResourceDataRaw(t, resourcePostgreSQLFunction().Schema, attributes)
+}

--- a/postgresql/resource_postgresql_function.go
+++ b/postgresql/resource_postgresql_function.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/lib/pq"
-	"log"
 )
 
 const (
@@ -14,6 +16,7 @@ const (
 	funcSchemaAttr      = "schema"
 	funcBodyAttr        = "body"
 	funcArgAttr         = "arg"
+	funcLanguageAttr    = "language"
 	funcReturnsAttr     = "returns"
 	funcDropCascadeAttr = "drop_cascade"
 	funcDatabaseAttr    = "database"
@@ -42,6 +45,8 @@ func resourcePostgreSQLFunction() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 				Description: "Schema where the function is located. If not specified, the provider default schema is used.",
+
+				DiffSuppressFunc: defaultDiffSuppressFunc,
 			},
 			funcNameAttr: {
 				Type:        schema.TypeString,
@@ -71,6 +76,13 @@ func resourcePostgreSQLFunction() *schema.Resource {
 							Optional:    true,
 							Default:     "IN",
 							ForceNew:    true,
+
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								if (new == "" && old == "IN") || (new == "IN" && old == "") {
+									return true
+								}
+								return old == new
+							},
 						},
 						funcArgDefaultAttr: {
 							Type:        schema.TypeString,
@@ -83,16 +95,35 @@ func resourcePostgreSQLFunction() *schema.Resource {
 				ForceNew:    true,
 				Description: "Function argument definitions.",
 			},
+			funcLanguageAttr: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "plpgsql",
+				Description: "Language of theof the function. One of: internal, sql, c, plpgsql",
+
+				DiffSuppressFunc: defaultDiffSuppressFunc,
+			},
 			funcReturnsAttr: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "Function return type.",
+				Computed:    true,
+				Description: "Function return type. If not specified, it will be calculated based on the output arguments",
+
+				DiffSuppressFunc: defaultDiffSuppressFunc,
 			},
 			funcBodyAttr: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Body of the function.",
+
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return normalizeFunctionBody(new) == old
+				},
+				StateFunc: func(val interface{}) string {
+					return normalizeFunctionBody(val.(string))
+				},
 			},
 			funcDropCascadeAttr: {
 				Type:        schema.TypeBool,
@@ -106,6 +137,8 @@ func resourcePostgreSQLFunction() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 				Description: "The database where the function is located. If not specified, the provider default database is used.",
+
+				DiffSuppressFunc: defaultDiffSuppressFunc,
 			},
 		},
 	}
@@ -134,16 +167,23 @@ func resourcePostgreSQLFunctionExists(db *DBConnection, d *schema.ResourceData) 
 		)
 	}
 
-	signature := getFunctionSignature(d)
-	functionExists := false
+	functionId := d.Id()
 
-	txn, err := startTransaction(db.client, d.Get(funcDatabaseAttr).(string))
+	databaseName, functionSignature, expandErr := expandFunctionID(functionId, d, db)
+	if expandErr != nil {
+		return false, expandErr
+	}
+
+	var functionExists bool
+
+	txn, err := startTransaction(db.client, databaseName)
 	if err != nil {
 		return false, err
 	}
 	defer deferredRollback(txn)
 
-	query := fmt.Sprintf("SELECT to_regprocedure('%s') IS NOT NULL", signature)
+	query := fmt.Sprintf("SELECT to_regprocedure('%s') IS NOT NULL AS functionExists", functionSignature)
+
 	if err := txn.QueryRow(query).Scan(&functionExists); err != nil {
 		return false, err
 	}
@@ -167,25 +207,35 @@ func resourcePostgreSQLFunctionRead(db *DBConnection, d *schema.ResourceData) er
 }
 
 func resourcePostgreSQLFunctionReadImpl(db *DBConnection, d *schema.ResourceData) error {
-	signature := getFunctionSignature(d)
+	functionId := d.Id()
 
-	var funcSchema, funcName string
+	if functionId == "" {
+		// Generate during creation
+		functionId = generateFunctionID(db, d)
+	}
 
-	query := `SELECT n.nspname, p.proname ` +
+	databaseName, functionSignature, expandErr := expandFunctionID(functionId, d, db)
+	if expandErr != nil {
+		return expandErr
+	}
+
+	var funcDefinition string
+
+	query := `SELECT pg_get_functiondef(p.oid::regproc) funcDefinition ` +
 		`FROM pg_proc p ` +
 		`LEFT JOIN pg_namespace n ON p.pronamespace = n.oid ` +
 		`WHERE p.oid = to_regprocedure($1)`
 
-	txn, err := startTransaction(db.client, d.Get(funcDatabaseAttr).(string))
+	txn, err := startTransaction(db.client, databaseName)
 	if err != nil {
 		return err
 	}
 	defer deferredRollback(txn)
 
-	err = txn.QueryRow(query, signature).Scan(&funcSchema, &funcName)
+	err = txn.QueryRow(query, functionSignature).Scan(&funcDefinition)
 	switch {
 	case err == sql.ErrNoRows:
-		log.Printf("[WARN] PostgreSQL function: %s", signature)
+		log.Printf("[WARN] PostgreSQL function: %s", functionId)
 		d.SetId("")
 		return nil
 	case err != nil:
@@ -196,15 +246,30 @@ func resourcePostgreSQLFunctionReadImpl(db *DBConnection, d *schema.ResourceData
 		return err
 	}
 
-	if v, ok := d.GetOk(funcDatabaseAttr); ok {
-		d.Set(funcDatabaseAttr, v)
-	} else {
-		d.Set(funcDatabaseAttr, db.client.databaseName)
+	var pgFunction PGFunction
+
+	pgFunction.Parse(funcDefinition)
+
+	var args []map[string]interface{}
+
+	for _, a := range pgFunction.Args {
+		args = append(args, map[string]interface{}{
+			funcArgTypeAttr:    a.Type,
+			funcArgNameAttr:    a.Name,
+			funcArgModeAttr:    a.Mode,
+			funcArgDefaultAttr: a.Default,
+		})
 	}
 
-	d.Set(funcNameAttr, funcName)
-	d.Set(funcSchemaAttr, funcSchema)
-	d.SetId(signature)
+	d.Set(funcDatabaseAttr, databaseName)
+	d.Set(funcNameAttr, pgFunction.Name)
+	d.Set(funcSchemaAttr, pgFunction.Schema)
+	d.Set(funcLanguageAttr, pgFunction.Language)
+	d.Set(funcReturnsAttr, pgFunction.Returns)
+	d.Set(funcBodyAttr, pgFunction.Body)
+	d.Set(funcArgAttr, args)
+
+	d.SetId(functionId)
 
 	return nil
 }
@@ -217,16 +282,19 @@ func resourcePostgreSQLFunctionDelete(db *DBConnection, d *schema.ResourceData) 
 		)
 	}
 
-	signature := getFunctionSignature(d)
+	databaseName, functionSignature, err := expandFunctionID(d.Id(), d, db)
+	if err != nil {
+		return err
+	}
 
 	dropMode := "RESTRICT"
 	if v, ok := d.GetOk(funcDropCascadeAttr); ok && v.(bool) {
 		dropMode = "CASCADE"
 	}
 
-	sql := fmt.Sprintf("DROP FUNCTION IF EXISTS %s %s", signature, dropMode)
+	sql := fmt.Sprintf("DROP FUNCTION IF EXISTS %s %s", functionSignature, dropMode)
 
-	txn, err := startTransaction(db.client, d.Get(funcDatabaseAttr).(string))
+	txn, err := startTransaction(db.client, databaseName)
 	if err != nil {
 		return err
 	}
@@ -261,6 +329,10 @@ func resourcePostgreSQLFunctionUpdate(db *DBConnection, d *schema.ResourceData) 
 }
 
 func createFunction(db *DBConnection, d *schema.ResourceData, replace bool) error {
+
+	var pgFunction PGFunction
+	pgFunction.FromResourceData(d)
+
 	b := bytes.NewBufferString("CREATE ")
 
 	if replace {
@@ -269,55 +341,42 @@ func createFunction(db *DBConnection, d *schema.ResourceData, replace bool) erro
 
 	b.WriteString("FUNCTION ")
 
-	if v, ok := d.GetOk(funcSchemaAttr); ok {
-		fmt.Fprint(b, pq.QuoteIdentifier(v.(string)), ".")
+	fmt.Fprint(b, pq.QuoteIdentifier(pgFunction.Schema), ".")
+
+	fmt.Fprint(b, pq.QuoteIdentifier(pgFunction.Name), " (")
+
+	for i, arg := range pgFunction.Args {
+		if i > 0 {
+			b.WriteRune(',')
+		}
+
+		b.WriteString("\n    ")
+
+		if arg.Mode != "" {
+			fmt.Fprint(b, arg.Mode, " ")
+		}
+
+		if arg.Name != "" {
+			fmt.Fprint(b, arg.Name, " ")
+		}
+
+		b.WriteString(arg.Type)
+
+		if arg.Default != "" {
+			fmt.Fprint(b, " DEFAULT ", arg.Default)
+		}
 	}
 
-	fmt.Fprint(b, pq.QuoteIdentifier(d.Get(funcNameAttr).(string)), " (")
-
-	if args, ok := d.GetOk(funcArgAttr); ok {
-		args := args.([]interface{})
-
-		for i, arg := range args {
-			arg := arg.(map[string]interface{})
-
-			if i > 0 {
-				b.WriteRune(',')
-			}
-
-			b.WriteString("\n    ")
-
-			if v, ok := arg[funcArgModeAttr]; ok {
-				fmt.Fprint(b, v.(string), " ")
-			}
-
-			if v, ok := arg[funcArgNameAttr]; ok {
-				fmt.Fprint(b, v.(string), " ")
-			}
-
-			b.WriteString(arg[funcArgTypeAttr].(string))
-
-			if v, ok := arg[funcArgDefaultAttr]; ok {
-				v := v.(string)
-
-				if len(v) > 0 {
-					fmt.Fprint(b, " DEFAULT ", v)
-				}
-			}
-		}
-
-		if len(args) > 0 {
-			b.WriteRune('\n')
-		}
+	if len(pgFunction.Args) > 0 {
+		b.WriteRune('\n')
 	}
 
 	b.WriteString(")")
 
-	if v, ok := d.GetOk(funcReturnsAttr); ok {
-		fmt.Fprint(b, " RETURNS ", v.(string))
-	}
+	fmt.Fprint(b, "\nRETURNS ", pgFunction.Returns)
+	fmt.Fprint(b, "\nLANGUAGE ", pgFunction.Language)
 
-	fmt.Fprint(b, "\n", d.Get(funcBodyAttr).(string))
+	fmt.Fprint(b, "\nAS $function$", pgFunction.Body, "$function$;")
 
 	sql := b.String()
 
@@ -338,39 +397,84 @@ func createFunction(db *DBConnection, d *schema.ResourceData, replace bool) erro
 	return nil
 }
 
-func getFunctionSignature(d *schema.ResourceData) string {
+func generateFunctionID(db *DBConnection, d *schema.ResourceData) string {
+
 	b := bytes.NewBufferString("")
 
-	if v, ok := d.GetOk(funcSchemaAttr); ok {
-		fmt.Fprint(b, pq.QuoteIdentifier(v.(string)), ".")
+	if dbAttr, ok := d.GetOk(funcDatabaseAttr); ok {
+		fmt.Fprint(b, dbAttr.(string), ".")
+	} else {
+		fmt.Fprint(b, db.client.databaseName, ".")
 	}
 
-	fmt.Fprint(b, pq.QuoteIdentifier(d.Get(funcNameAttr).(string)), "(")
+	var pgFunction PGFunction
+	pgFunction.FromResourceData(d)
 
-	if args, ok := d.GetOk(funcArgAttr); ok {
-		argCount := 0
+	fmt.Fprint(b, pgFunction.Schema, ".", pgFunction.Name, "(")
 
-		for _, arg := range args.([]interface{}) {
-			arg := arg.(map[string]interface{})
+	argCount := 0
 
-			mode := "IN"
+	for _, arg := range pgFunction.Args {
+		mode := "IN"
+		if arg.Mode != "" {
+			mode = arg.Mode
+		}
 
-			if v, ok := arg[funcArgModeAttr]; ok {
-				mode = v.(string)
+		if mode != "OUT" {
+			if argCount > 0 {
+				b.WriteRune(',')
 			}
 
-			if mode != "OUT" {
-				if argCount > 0 {
-					b.WriteRune(',')
-				}
-
-				b.WriteString(arg[funcArgTypeAttr].(string))
-				argCount += 1
-			}
+			b.WriteString(arg.Type)
+			argCount += 1
 		}
 	}
 
 	b.WriteRune(')')
 
 	return b.String()
+}
+
+func expandFunctionID(functionId string, d *schema.ResourceData, db *DBConnection) (databaseName string, functionSignature string, err error) {
+
+	partsCount := strings.Count(functionId, ".") + 1
+
+	if partsCount == 2 {
+		clientDatabaseName := "postgres"
+		if db != nil {
+			clientDatabaseName = db.client.databaseName
+		}
+
+		signature, err := quoteSignature(functionId)
+		if err != nil {
+			return "", "", err
+		}
+
+		return getDatabase(d, clientDatabaseName), signature, nil
+	}
+
+	if partsCount == 3 {
+		functionIdParts := strings.Split(functionId, ".")
+		signature, err := quoteSignature(strings.Join(functionIdParts[1:], "."))
+		if err != nil {
+			return "", "", err
+		}
+		return functionIdParts[0], signature, nil
+	}
+
+	return "", "", fmt.Errorf("function ID %s has not the expected format 'database.schema.function_name(arguments)'", functionId)
+}
+
+func quoteSignature(s string) (signature string, err error) {
+
+	signatureData := findStringSubmatchMap(`(?si)(?P<Schema>[^\.]+)\.(?P<Name>[^(]+)\((?P<Args>.*)\)`, s)
+
+	schemaName, schemaFound := signatureData["Schema"]
+	name, nameFound := signatureData["Name"]
+	args, argsFound := signatureData["Args"]
+	if schemaFound && nameFound && argsFound {
+		return fmt.Sprintf("%s.%s(%s)", pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(name), args), nil
+	}
+
+	return "", fmt.Errorf("Incorrect signature format \"%s\". The expected format is schema.function_name(arguments)", s)
 }

--- a/postgresql/resource_postgresql_function_test.go
+++ b/postgresql/resource_postgresql_function_test.go
@@ -252,8 +252,13 @@ func testAccCheckPostgresqlFunctionDestroy(s *terraform.State) error {
 		}
 		defer deferredRollback(txn)
 
-		signature := rs.Primary.ID
-		exists, err := checkFunctionExists(txn, signature)
+		_, functionSignature, expandErr := expandFunctionID(rs.Primary.ID, nil, nil)
+
+		if expandErr != nil {
+			return fmt.Errorf("Incorrect resource Id %s", err)
+		}
+
+		exists, err := checkFunctionExists(txn, functionSignature)
 
 		if err != nil {
 			return fmt.Errorf("Error checking function %s", err)

--- a/website/docs/r/postgresql_function.html.markdown
+++ b/website/docs/r/postgresql_function.html.markdown
@@ -21,12 +21,11 @@ resource "postgresql_function" "increment" {
         type = "integer"
     }
     returns = "integer"
+    language = "plpgsql"
     body = <<-EOF
-        AS $$
         BEGIN
             RETURN i + 1;
         END;
-        $$ LANGUAGE plpgsql;
     EOF
 }
 ```
@@ -47,10 +46,26 @@ resource "postgresql_function" "increment" {
   * `mode` - (Optional) Can be one of IN, INOUT, OUT, or VARIADIC. Default is IN.
   * `default` - (Optional) An expression to be used as default value if the parameter is not specified.
 
-* `returns` - (Optional) Type that the function returns.
+* `returns` - (Optional) Type that the function returns. It can be computed from the OUT arguments. Default is void.
+
+* `language` - (Optional) The function programming language. Can be one of internal, sql, c, plpgsql. Default is plpgsql.
 
 * `body` - (Required) Function body.
-  This should be everything after the return type in the function definition.
+  This should be the body content withing the `AS $$` and the final `$$`. It will also accept the `AS $$` and `$$` if added.
 
 * `drop_cascade` - (Optional) True to automatically drop objects that depend on the function (such as 
   operators or triggers), and in turn all objects that depend on those objects. Default is false.
+
+## Import 
+
+It is possible to import a `postgresql_function` resource with the following
+command:
+
+```
+$ terraform import postgresql_function.function_foo "my_database.my_schema.my_function_name(arguments)"
+```
+
+Where `my_database` is the name of the database containing the schema,
+`my_schema` is the name of the schema in the PostgreSQL database, `my_function_name` is the function name to be imported, `arguments` is the argument signature of the function including all non OUT types and
+`postgresql_schema.function_foo` is the name of the resource whose state will be
+populated as a result of the command.


### PR DESCRIPTION
Hi @cyrilgdn ,

I am creating the pull request to add function import capability.

The read implement is also partial and doesn't detect db changes specially for the body.

The main changes are adding the database in the id and updating the expected body value  to be able to support the import.
The existing definition is loaded by the predefined function `pg_get_functiondef`.
The language was extracted as a new attribute

It will solve the following issue: #221