### PR TITLE
fix: drop cascade for extensions and schemas

### DIFF
--- a/postgresql/resource_postgresql_extension.go
+++ b/postgresql/resource_postgresql_extension.go
@@ -170,6 +170,7 @@ func resourcePostgreSQLExtensionRead(db *DBConnection, d *schema.ResourceData) e
 }
 
 func resourcePostgreSQLExtensionReadImpl(db *DBConnection, d *schema.ResourceData) error {
+	dropCascade := d.Get(extDropCascadeAttr).(bool)
 	database, extName, err := getDBExtName(d, db.client)
 	if err != nil {
 		return err
@@ -199,6 +200,7 @@ func resourcePostgreSQLExtensionReadImpl(db *DBConnection, d *schema.ResourceDat
 	d.Set(extSchemaAttr, extSchema)
 	d.Set(extVersionAttr, extVersion)
 	d.Set(extDatabaseAttr, database)
+	d.Set(extDropCascadeAttr, dropCascade)
 	d.SetId(generateExtensionID(d, database))
 
 	return nil

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -309,6 +309,7 @@ func resourcePostgreSQLSchemaRead(db *DBConnection, d *schema.ResourceData) erro
 }
 
 func resourcePostgreSQLSchemaReadImpl(db *DBConnection, d *schema.ResourceData) error {
+	dropCascade := d.Get(schemaDropCascade).(bool)
 	database, schemaName, err := getDBSchemaName(d, db.client.databaseName)
 	if err != nil {
 		return err
@@ -357,6 +358,7 @@ func resourcePostgreSQLSchemaReadImpl(db *DBConnection, d *schema.ResourceData) 
 		d.Set(schemaNameAttr, schemaName)
 		d.Set(schemaOwnerAttr, schemaOwner)
 		d.Set(schemaDatabaseAttr, database)
+		d.Set(schemaDropCascade, dropCascade)
 		d.SetId(generateSchemaID(d, database))
 
 		return nil


### PR DESCRIPTION
When creating extensions or schemas we can provide a boolean value for the `drop_cascade` argument. Unfortunately, this value is never picked up and it always defaults to false.

If we have the following resource:

```hcl
resource "postgresql_schema" "my_schema" {
  name  = "my_schema"
  owner = "postgres"
  drop_cascade = false
}
```

And change it to this

```hcl
resource "postgresql_schema" "my_schema" {
  name  = "my_schema"
  owner = "postgres"
  drop_cascade = true
}
```

With the current version, there are no changes to plan.


I don't have a way to test this locally on my machine, so would be great if someone could test this.
