### PR TITLE
Support role configuration parameters

### DIFF
--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -35,10 +35,22 @@ const (
 	roleSearchPathAttr                      = "search_path"
 	roleStatementTimeoutAttr                = "statement_timeout"
 	roleAssumeRoleAttr                      = "assume_role"
+	roleParameterAttr                       = "parameter"
+	roleParameterNameAttr                   = "name"
+	roleParameterValueAttr                  = "value"
+	roleParameterQuoteAttr                  = "quote"
 
 	// Deprecated options
 	roleDepEncryptedAttr = "encrypted"
 )
+
+// These parameters have discrete attributes, so they are not supported by the parameter block
+var ignoredRoleConfigurationParameters = []string{
+	roleSearchPathAttr,
+	roleIdleInTransactionSessionTimeoutAttr,
+	roleStatementTimeoutAttr,
+	"role",
+}
 
 func resourcePostgreSQLRole() *schema.Resource {
 	return &schema.Resource{
@@ -172,6 +184,36 @@ func resourcePostgreSQLRole() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Role to switch to at login",
+			},
+			roleParameterAttr: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Configuration parameters",
+				Elem:        resourcePostgreSQLRoleConfigurationParameter(),
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLRoleConfigurationParameter() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			roleParameterNameAttr: {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "Name of the configuration parameter to set",
+				ValidateFunc: validation.StringNotInSlice(ignoredRoleConfigurationParameters, true),
+			},
+			roleParameterValueAttr: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Value of the configuration parameter",
+			},
+			roleParameterQuoteAttr: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Quote the parameter value as a literal",
 			},
 		},
 	}
@@ -308,6 +350,10 @@ func resourcePostgreSQLRoleCreate(db *DBConnection, d *schema.ResourceData) erro
 	}
 
 	if err = setAssumeRole(txn, d); err != nil {
+		return err
+	}
+
+	if err = setConfigurationParameters(txn, d); err != nil {
 		return err
 	}
 
@@ -480,6 +526,8 @@ func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) er
 	}
 
 	d.Set(rolePasswordAttr, password)
+
+	d.Set(roleParameterAttr, readRoleParameters(roleConfig, d.Get(roleParameterAttr).(*schema.Set)))
 	return nil
 }
 
@@ -545,6 +593,28 @@ func readAssumeRole(roleConfig pq.ByteaArray) string {
 		}
 	}
 	return res
+}
+
+func readRoleParameters(roleConfig pq.ByteaArray, existingParams *schema.Set) *schema.Set {
+	params := make([]interface{}, 0)
+	for _, v := range roleConfig {
+		tokens := strings.Split(string(v), "=")
+		if !sliceContainsStr(ignoredRoleConfigurationParameters, tokens[0]) {
+			quote := true
+			for _, p := range existingParams.List() {
+				existingParam := p.(map[string]interface{})
+				if existingParam[roleParameterNameAttr].(string) == tokens[0] {
+					quote = existingParam[roleParameterQuoteAttr].(bool)
+				}
+			}
+			params = append(params, map[string]interface{}{
+				roleParameterNameAttr:  tokens[0],
+				roleParameterValueAttr: tokens[1],
+				roleParameterQuoteAttr: quote,
+			})
+		}
+	}
+	return schema.NewSet(schema.HashResource(resourcePostgreSQLRoleConfigurationParameter()), params)
 }
 
 // readRolePassword reads password either from Postgres if admin user is a superuser
@@ -686,6 +756,10 @@ func resourcePostgreSQLRoleUpdate(db *DBConnection, d *schema.ResourceData) erro
 	}
 
 	if err = setAssumeRole(txn, d); err != nil {
+		return err
+	}
+
+	if err = setConfigurationParameters(txn, d); err != nil {
 		return err
 	}
 
@@ -956,6 +1030,47 @@ func grantRoles(txn *sql.Tx, d *schema.ResourceData) error {
 		)
 		if _, err := txn.Exec(query); err != nil {
 			return fmt.Errorf("could not grant role %s to %s: %w", grantingRole, role, err)
+		}
+	}
+	return nil
+}
+
+func setConfigurationParameters(txn *sql.Tx, d *schema.ResourceData) error {
+	role := d.Get(roleNameAttr).(string)
+	if d.HasChange(roleParameterAttr) {
+		o, n := d.GetChange(roleParameterAttr)
+		oldParams := o.(*schema.Set)
+		newParams := n.(*schema.Set)
+		for _, p := range oldParams.List() {
+			if !newParams.Contains(p) {
+				param := p.(map[string]interface{})
+				query := fmt.Sprintf(
+					"ALTER ROLE %s RESET %s",
+					pq.QuoteIdentifier(role),
+					pq.QuoteIdentifier(param[roleParameterNameAttr].(string)))
+				log.Printf("[DEBUG] setConfigurationParameters: %s", query)
+				if _, err := txn.Exec(query); err != nil {
+					return err
+				}
+			}
+		}
+		for _, p := range newParams.List() {
+			if !oldParams.Contains(p) {
+				param := p.(map[string]interface{})
+				value := param[roleParameterValueAttr].(string)
+				if param[roleParameterQuoteAttr].(bool) {
+					value = pq.QuoteLiteral(value)
+				}
+				query := fmt.Sprintf(
+					"ALTER ROLE %s SET %s TO %s",
+					pq.QuoteIdentifier(role),
+					pq.QuoteIdentifier(param[roleParameterNameAttr].(string)),
+					value)
+				log.Printf("[DEBUG] setConfigurationParameters: %s", query)
+				if _, err := txn.Exec(query); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Adds an optional, repeatable `parameter` block to the `postgresql_role` resource, which is used to define arbitary configuration parameters for the role. This is equivalent to using `ALTER ROLE [role] SET [param] TO [value]`.

Example:
```
resource "postgresql_role" "test_role" {
  name = "audited_user"

  parameter {
    name  = "pgaudit.log"
    value = "all"
  }
}
```

This is more or less an alternate implementation to #211, and is in line with the suggestion in a [comment](https://github.com/cyrilgdn/terraform-provider-postgresql/pull/211#issuecomment-1469269398) on that PR.

Some implementation notes:

1. Some configuration parameters are already supported by dedicated arguments: `search_path`, `statement_timeout`, `idle_in_transaction_timeout`, and `role`. To prevent those existing arguments from conflicting with this one and causing perpetual diffs, those parameters cannot be set with a `parameter` block.
2. There are some peculiarities with value quoting:

    Most general configuration parameters, for example `client_min_messages`, can either be quoted string literals or bare tokens in the `ALTER ROLE` statement. At least one — `search_path` — _cannot_ be quoted. Or rather, quoting will give you unexpected results. Others, for instance `pgaudit.log`, _must_ be quoted, or the statement will produce an error.

    To accommodate all circumstances including ones I wasn't able to personally test, I opted to include an optional `quote` property in the `parameter` block that defaults to true, so quoting can be selectively disabled if required.

Closes #210 