### PR TITLE
Bypass role grant logic for `pg_database_owner` role

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -149,6 +149,11 @@ func withRolesGranted(txn *sql.Tx, roles []string, fn func() error) error {
 	var revokedRoles []string
 
 	for _, role := range roles {
+		// The `pg_database_owner` role (https://www.postgresql.org/docs/current/predefined-roles.html)
+		// Is a built-in role in PG 14 and later that cannot be manipulated with the below logic
+		if role == "pg_database_owner" {
+			continue
+		}
 		// We need to check if the role we want to grant is a superuser
 		// in this case Postgres disallows to grant it to a current user which is not superuser.
 		superuser, err := isSuperuser(txn, role)


### PR DESCRIPTION
See issue #301. This appears to solve the issue, but may have unanticipated side-effects.

This is my _incredibly naive_ attempt at fixing the issue here. I don't understand enough of what is being done here and why to understand if this is a terrible idea, or what limitations this will introduce. I imagine that without this, if Terraform is using a role that doesn't have proper permissions to grant permissions, it will fail (but for a different reason), which may be why this code was originally in place.

I have tried this out by debugging locally with this change in place on a state impacted by the failure in https://github.com/cyrilgdn/terraform-provider-postgresql/issues/301 and it was able to apply for my state without a problem.

I would love to get any feedback on what this PR would need to be up to necessary standards to be pulled in.