### PR TITLE
feat: Allow for inlining client cert

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -149,6 +149,7 @@ func (db *DBConnection) isSuperuser() (bool, error) {
 type ClientCertificateConfig struct {
 	CertificatePath string
 	KeyPath         string
+	SSLInline       bool
 }
 
 // Config - provider config
@@ -215,6 +216,9 @@ func (c *Config) connParams() []string {
 	if c.SSLClientCert != nil {
 		params["sslcert"] = c.SSLClientCert.CertificatePath
 		params["sslkey"] = c.SSLClientCert.KeyPath
+		if c.SSLClientCert.SSLInline {
+			params["sslinline"] = strconv.FormatBool(c.SSLClientCert.SSLInline)
+		}
 	}
 
 	if c.SSLRootCertPath != "" {

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -130,6 +130,11 @@ func Provider() *schema.Provider {
 							Description: "The SSL client certificate private key file path. The file must contain PEM encoded data.",
 							Required:    true,
 						},
+						"sslinline": {
+							Type:        schema.TypeBool,
+							Description: "Must be set to true if you are inlining the cert/key instead of using a file path.",
+							Optional:    true,
+						},
 					},
 				},
 				MaxItems: 1,
@@ -296,6 +301,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			config.SSLClientCert = &ClientCertificateConfig{
 				CertificatePath: spec["cert"].(string),
 				KeyPath:         spec["key"].(string),
+				SSLInline:       spec["sslinline"].(bool),
 			}
 		}
 	}


### PR DESCRIPTION
It is useful when you are using Google Cloud SQL and don't want to
be forced to use temporary files to load certificate
