### PR TITLE
fixed escaping for postgresql user info

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -11,7 +11,7 @@ import (
 	"unicode"
 
 	"github.com/blang/semver"
-	_ "github.com/lib/pq" //PostgreSQL db
+	_ "github.com/lib/pq" // PostgreSQL db
 	"gocloud.dev/postgres"
 	_ "gocloud.dev/postgres/awspostgres"
 	_ "gocloud.dev/postgres/gcppostgres"
@@ -245,8 +245,8 @@ func (c *Config) connStr(database string) string {
 	connStr := fmt.Sprintf(
 		"%s://%s:%s@%s:%d/%s?%s",
 		c.Scheme,
-		url.QueryEscape(c.Username),
-		url.QueryEscape(c.Password),
+		url.PathEscape(c.Username),
+		url.PathEscape(c.Password),
 		host,
 		c.Port,
 		database,
@@ -302,7 +302,7 @@ func (c *Client) Connect() (*DBConnection, error) {
 			// Version hint not set by user, need to fingerprint
 			version, err = fingerprintCapabilities(db)
 			if err != nil {
-				db.Close()
+				_ = db.Close()
 				return nil, fmt.Errorf("error detecting capabilities: %w", err)
 			}
 		}

--- a/postgresql/config_test.go
+++ b/postgresql/config_test.go
@@ -45,6 +45,7 @@ func TestConfigConnStr(t *testing.T) {
 		wantDbParams []string
 	}{
 		{&Config{Scheme: "postgres", Host: "localhost", Port: 5432, Username: "postgres_user", Password: "postgres_password", SSLMode: "disable"}, "postgres://postgres_user:postgres_password@localhost:5432/postgres", []string{"connect_timeout=0", "sslmode=disable"}},
+		{&Config{Scheme: "postgres", Host: "localhost", Port: 5432, Username: "spaced user", Password: "spaced password", SSLMode: "disable"}, "postgres://spaced%20user:spaced%20password@localhost:5432/postgres", []string{"connect_timeout=0", "sslmode=disable"}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
User info is using wrong escaping type.
`url.PathEscape(string)` is correct for postgresql driver

This is fixing #345 