### PR TITLE
Fix getting stuck on refreshing postgresql grant

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  timeout: 5m
+
 issues:
   exclude-rules:
     - linters:

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -87,7 +87,7 @@ func resourcePostgreSQLDefaultPrivilegesRead(db *DBConnection, d *schema.Resourc
 		)
 	}
 
-	exists, err := checkRoleDBSchemaExists(db.client, d)
+	exists, err := checkRoleDBSchemaExists(db, d)
 	if err != nil {
 		return err
 	}

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -730,6 +730,8 @@ func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, erro
 		return false, nil
 	}
 
+	deferredRollback(txn)
+
 	pgSchema := d.Get("schema").(string)
 
 	if !sliceContainsStr([]string{"database", "foreign_data_wrapper", "foreign_server"}, d.Get("object_type").(string)) && pgSchema != "" {

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -109,7 +109,7 @@ func resourcePostgreSQLGrantRead(db *DBConnection, d *schema.ResourceData) error
 		return fmt.Errorf("feature is not supported: %v", err)
 	}
 
-	exists, err := checkRoleDBSchemaExists(db.client, d)
+	exists, err := checkRoleDBSchemaExists(db, d)
 	if err != nil {
 		return err
 	}
@@ -699,8 +699,19 @@ func revokeRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 	return nil
 }
 
-func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, error) {
-	txn, err := startTransaction(client, "")
+func checkRoleDBSchemaExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
+	// Check the database exists
+	database := d.Get("database").(string)
+	exists, err := dbExists(db, database)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] database %s does not exists", database)
+		return false, nil
+	}
+
+	txn, err := startTransaction(db.client, database)
 	if err != nil {
 		return false, err
 	}
@@ -719,31 +730,10 @@ func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, erro
 		}
 	}
 
-	// Check the database exists
-	database := d.Get("database").(string)
-	exists, err := dbExists(txn, database)
-	if err != nil {
-		return false, err
-	}
-	if !exists {
-		log.Printf("[DEBUG] database %s does not exists", database)
-		return false, nil
-	}
-
-	deferredRollback(txn)
-
+	// Check the schema exists (the SQL connection needs to be on the right database)
 	pgSchema := d.Get("schema").(string)
-
 	if !sliceContainsStr([]string{"database", "foreign_data_wrapper", "foreign_server"}, d.Get("object_type").(string)) && pgSchema != "" {
-		// Connect on this database to check if schema exists
-		dbTxn, err := startTransaction(client, database)
-		if err != nil {
-			return false, err
-		}
-		defer deferredRollback(dbTxn)
-
-		// Check the schema exists (the SQL connection needs to be on the right database)
-		exists, err = schemaExists(dbTxn, pgSchema)
+		exists, err = schemaExists(txn, pgSchema)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
This change fixes terraform refresh getting stuck forever on postgresql_grant schema when provider connection database is the same as the one we are trying to read schema information from. Until now the issue could be reproduced only on RDS (PostgreSQL 14.7). Fixed by explicitly finishing one transaction before starting a new one.

Fixes #335