### PR TITLE
Fix for `Error: could not execute revoke query: pq: tuple concurrently updated`

### DIFF
--- a/examples/issues/178/locals.tf
+++ b/examples/issues/178/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  read_only_users  = ["fu", "bar"]
+  read_write_users = ["blah", "bzz"]
+}

--- a/examples/issues/178/main.tf
+++ b/examples/issues/178/main.tf
@@ -1,0 +1,160 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = ">= 3.0.2"
+    }
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "1.21"
+    }
+    # postgresql = {
+    #   source  = "terraform-fu.bar/terraform-provider-postgresql/postgresql"
+    #   version = ">= 1.20"
+    # }
+  }
+}
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}
+
+resource "docker_image" "postgres" {
+  name         = var.postgres_image
+  keep_locally = var.keep_image
+}
+
+resource "docker_container" "postgres" {
+  image = docker_image.postgres.image_id
+  name  = "postgres"
+  wait  = true
+  ports {
+    internal = var.POSTGRES_PORT
+    external = var.POSTGRES_PORT
+  }
+  env = [
+    "POSTGRES_PASSWORD=${var.POSTGRES_PASSWORD}"
+  ]
+  healthcheck {
+    test         = ["CMD-SHELL", "pg_isready"]
+    interval     = "5s"
+    timeout      = "5s"
+    retries      = 5
+    start_period = "2s"
+  }
+}
+
+provider "postgresql" {
+  scheme    = "postgres"
+  host      = var.POSTGRES_HOST
+  port      = docker_container.postgres.ports[0].external
+  database  = var.POSTGRES_PASSWORD
+  username  = var.POSTGRES_PASSWORD
+  password  = var.POSTGRES_PASSWORD
+  sslmode   = "disable"
+  superuser = false
+}
+
+resource "postgresql_database" "this" {
+  name  = "test"
+  owner = var.POSTGRES_USER
+}
+
+resource "postgresql_role" "readonly_role" {
+  name             = "readonly"
+  login            = false
+  superuser        = false
+  create_database  = false
+  create_role      = false
+  inherit          = false
+  replication      = false
+  connection_limit = -1
+}
+
+resource "postgresql_role" "readwrite_role" {
+  name             = "readwrite"
+  login            = false
+  superuser        = false
+  create_database  = false
+  create_role      = false
+  inherit          = false
+  replication      = false
+  connection_limit = -1
+}
+
+resource "postgresql_grant" "readonly_role" {
+  database          = postgresql_database.this.name
+  role              = postgresql_role.readonly_role.name
+  object_type       = "table"
+  schema            = "public"
+  privileges        = ["SELECT"]
+  with_grant_option = false
+}
+
+resource "postgresql_grant" "readwrite_role" {
+  database          = postgresql_database.this.name
+  role              = postgresql_role.readwrite_role.name
+  object_type       = "table"
+  schema            = "public"
+  privileges        = ["SELECT", "INSERT", "UPDATE", "DELETE"]
+  with_grant_option = false
+}
+
+resource "postgresql_role" "readonly_users" {
+  for_each         = toset(local.read_only_users)
+  name             = each.key
+  roles            = [postgresql_role.readonly_role.name]
+  login            = true
+  superuser        = false
+  create_database  = false
+  create_role      = false
+  inherit          = true
+  replication      = false
+  connection_limit = -1
+}
+
+resource "postgresql_role" "readwrite_users" {
+  for_each         = toset(local.read_write_users)
+  name             = each.key
+  roles            = [postgresql_role.readonly_role.name]
+  login            = true
+  superuser        = false
+  create_database  = false
+  create_role      = false
+  inherit          = true
+  replication      = false
+  connection_limit = -1
+}
+
+resource "postgresql_grant" "connect_db_readonly_role" {
+  database    = postgresql_database.this.name
+  object_type = "database"
+  privileges  = ["CREATE", "CONNECT"]
+  role        = postgresql_role.readonly_role.name
+}
+
+resource "postgresql_grant" "connect_db_readwrite_role" {
+  database    = postgresql_database.this.name
+  object_type = "database"
+  privileges  = ["CREATE", "CONNECT"]
+  role        = postgresql_role.readwrite_role.name
+}
+
+resource "postgresql_grant" "usage_readonly_role" {
+  database          = postgresql_database.this.name
+  role              = postgresql_role.readonly_role.name
+  object_type       = "schema"
+  schema            = "public"
+  privileges        = ["USAGE"]
+  with_grant_option = false
+}
+
+resource "postgresql_grant" "usage_readwrite_role" {
+  database          = postgresql_database.this.name
+  role              = postgresql_role.readwrite_role.name
+  object_type       = "schema"
+  schema            = "public"
+  privileges        = ["USAGE"]
+  with_grant_option = false
+}
+

--- a/examples/issues/178/test.sh
+++ b/examples/issues/178/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eou pipefail
+i=0
+
+while [ $i -lt 10 ]; do
+    terraform apply -auto-approve
+    terraform destroy -auto-approve
+    i=$((i+1))
+done

--- a/examples/issues/178/variables.tf
+++ b/examples/issues/178/variables.tf
@@ -1,0 +1,39 @@
+variable "postgres_image" {
+  description = "Which postgres docker image to use."
+  default     = "postgres:15"
+  type        = string
+  sensitive   = false
+}
+
+variable "POSTGRES_USER" {
+  default   = "postgres"
+  type      = string
+  sensitive = false
+}
+
+variable "POSTGRES_PASSWORD" {
+  description = "Password for docker POSTGRES_USER"
+  default     = "postgres"
+  type        = string
+  sensitive   = false
+}
+
+variable "POSTGRES_HOST" {
+  default   = "127.0.0.1"
+  type      = string
+  sensitive = false
+}
+
+variable "POSTGRES_PORT" {
+  description = "Which port postgres should listen on."
+  default     = 5432
+  type        = number
+  sensitive   = false
+}
+
+variable "keep_image" {
+  description = "If true, then the Docker image won't be deleted on destroy operation. If this is false, it will delete the image from the docker local storage on destroy operation."
+  default     = true
+  type        = bool
+  sensitive   = false
+}

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -548,6 +548,15 @@ func pgLockRole(txn *sql.Tx, role string) error {
 	return nil
 }
 
+// Lock a schema avoid concurrent updates during revoke query.
+func pgLockSchema(txn *sql.Tx, schema string) error {
+	if _, err := txn.Exec("SELECT pg_advisory_xact_lock(oid::bigint) FROM pg_catalog.pg_namespace WHERE nspname = $1", schema); err != nil {
+		return fmt.Errorf("could not get advisory lock for schema %s: %w", schema, err)
+	}
+
+	return nil
+}
+
 // Lock a database and all his members to avoid concurrent updates on some resources
 func pgLockDatabase(txn *sql.Tx, database string) error {
 	// Disable statement timeout for this connection otherwise the lock could fail

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -693,6 +693,13 @@ func revokeRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 		// Query is empty, don't run anything
 		return nil
 	}
+
+	// Obtain a lock to avoid `Error: could not execute revoke query: pq: tuple concurrently updated`
+	schema := d.Get("schema").(string)
+	if err := pgLockSchema(txn, schema); err != nil {
+		return err
+	}
+
 	if _, err := txn.Exec(query); err != nil {
 		return fmt.Errorf("could not execute revoke query: %w", err)
 	}


### PR DESCRIPTION
This should be a fix for #178.

From what I can tell, the locks created in `pgLockRole` and `pgLockDatabase` were not sufficient to cover cases when we're messing with a schema, such as `REVOKE ALL PRIVILEGES ON SCHEMA %s FROM %s`.

I created a an example in `examples/issues/178` in which I was able to reproduce the error in almost 50% of `terraform apply` or `terraform destroy` operations.  With this change, the error hasn't been reproduced in over 30 such operations.