### PR TITLE
simplify the function parsing regex

### DIFF
--- a/postgresql/model_pg_function_test.go
+++ b/postgresql/model_pg_function_test.go
@@ -112,13 +112,13 @@ func TestPGFunctionParseWithArguments(t *testing.T) {
 CREATE OR REPLACE FUNCTION public.pg_func_test(showtext boolean, OUT userid oid, default_null integer DEFAULT NULL::integer, simple_default integer DEFAULT 42, long_default character varying DEFAULT 'foo'::character varying)
 RETURNS SETOF record
 LANGUAGE c
-STABLE PARALLEL SAFE STRICT SECURITY DEFINER
+SECURITY DEFINER STABLE STRICT PARALLEL SAFE
 AS $function$pg_func_test_body$function$
 	`
 
 	var pgFunction PGFunction
 
-	err := pgFunction.Parse(functionDefinition)
+	err := pgFunction.Parse(functionDefinition, true, true, "s", "s", "c")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ $function$
 
 	var pgFunction PGFunction
 
-	err := pgFunction.Parse(functionDefinition)
+	err := pgFunction.Parse(functionDefinition, false, false, "u", "v", "plpgsql")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Hello, this is a follow-up to https://github.com/cyrilgdn/terraform-provider-postgresql/pull/307/files

The regex to extract the function attributes relies on `pg_get_functiondef` to return the attributes in a specific order of `IMMUTABLE/STABLE`, then `PARALLEL SAFE/RESTRICTED`, then `STRICT`, then `SECURITY DEFINER`. And while the order is preserved across all current versions of Postgres as it is the order generated [by the function](https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/ruleutils.c#L2942), I would sleep better at night if these attributes were fetched from the source of truth in `pg_proc` rather than a regex parser :)