### PR TITLE
fix: Optional revoke on postgresql_grant_role

### DIFF
--- a/postgresql/resource_postgresql_grant_role.go
+++ b/postgresql/resource_postgresql_grant_role.go
@@ -81,11 +81,6 @@ func resourcePostgreSQLGrantRoleCreate(db *DBConnection, d *schema.ResourceData)
 	}
 	defer deferredRollback(txn)
 
-	// Revoke the granted roles before granting them again.
-	if err = revokeRole(txn, d); err != nil {
-		return err
-	}
-
 	if err = grantRole(txn, d); err != nil {
 		return err
 	}


### PR DESCRIPTION
Since PostgreSQL 16.0, there is a dependency check made when revoking grants on roles. 

Specifically, if role A has a grant with admin rights on role B, and uses these rights to grant role B to role C, then it can't be revoked without cascading.

This PR allows to use `postgresql_grant_role` without doing an initial `REVOKE` query. Our use case for this feature is applying two different DB stacks (one for development and one for unit testing) which share grants on common roles.