### PR TITLE
Allow define a search_path on the database

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -687,3 +687,20 @@ func quoteTableName(tableName string) string {
 	}
 	return strings.Join(parts, ".")
 }
+
+// readSearchPath searches for a search_path entry in the rolconfig array.
+// In case no such value is present, it returns nil.
+func readSearchPath(roleConfig pq.ByteaArray) []string {
+	searchPathPrefix := "search_path"
+	for _, v := range roleConfig {
+		config := string(v)
+		if strings.HasPrefix(config, searchPathPrefix) {
+			var result = strings.Split(strings.TrimPrefix(config, searchPathPrefix+"="), ", ")
+			for i := range result {
+				result[i] = strings.Trim(result[i], `"`)
+			}
+			return result
+		}
+	}
+	return nil
+}

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -25,6 +25,7 @@ const (
 	dbTablespaceAttr       = "tablespace_name"
 	dbTemplateAttr         = "template"
 	dbAlterObjectOwnership = "alter_object_ownership"
+	dbSearchPathAttr       = "search_path"
 )
 
 func resourcePostgreSQLDatabase() *schema.Resource {
@@ -108,6 +109,13 @@ func resourcePostgreSQLDatabase() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: "If true, the owner of already existing objects will change if the owner changes",
+			},
+			dbSearchPathAttr: {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				MinItems:    0,
+				Description: "Sets the database's search path",
 			},
 		},
 	}
@@ -229,6 +237,10 @@ func createDatabase(db *DBConnection, d *schema.ResourceData) error {
 	sql := b.String()
 	if _, err := db.Exec(sql); err != nil {
 		return fmt.Errorf("error creating database %q: %w", dbName, err)
+	}
+
+	if err := alterDBSearchPath(db, d); err != nil {
+		return err
 	}
 
 	// Set err outside of the return so that the deferred revoke can override err
@@ -357,6 +369,12 @@ func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData
 		return fmt.Errorf("error reading database: %w", err)
 	}
 
+	var dbRoleSettings pq.ByteaArray
+	dbRoleSettings, err = getDBRoleSettings(db, dbId)
+	if err != nil {
+		return err
+	}
+
 	d.Set(dbNameAttr, dbName)
 	d.Set(dbOwnerAttr, ownerName)
 	d.Set(dbEncodingAttr, dbEncoding)
@@ -364,6 +382,7 @@ func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData
 	d.Set(dbCTypeAttr, dbCType)
 	d.Set(dbTablespaceAttr, dbTablespaceName)
 	d.Set(dbConnLimitAttr, dbConnLimit)
+	d.Set(dbSearchPathAttr, readSearchPath(dbRoleSettings))
 	dbTemplate := d.Get(dbTemplateAttr).(string)
 	if dbTemplate == "" {
 		dbTemplate = "template0"
@@ -425,6 +444,10 @@ func resourcePostgreSQLDatabaseUpdate(db *DBConnection, d *schema.ResourceData) 
 	}
 
 	// Empty values: ALTER DATABASE name RESET configuration_parameter;
+
+	if err := alterDBSearchPath(db, d); err != nil {
+		return err
+	}
 
 	return resourcePostgreSQLDatabaseReadImpl(db, d)
 }
@@ -609,6 +632,39 @@ func setDBIsTemplate(db *DBConnection, d *schema.ResourceData) error {
 	return nil
 }
 
+func alterDBSearchPath(db *DBConnection, d *schema.ResourceData) error {
+	dbName := d.Get(dbNameAttr).(string)
+	searchPathInterface := d.Get(dbSearchPathAttr).([]interface{})
+
+	var searchPathString []string
+	if len(searchPathInterface) > 0 {
+		searchPathString = make([]string, len(searchPathInterface))
+		for i, searchPathPart := range searchPathInterface {
+			if strings.Contains(searchPathPart.(string), ", ") {
+				return fmt.Errorf("search_path cannot contain `, `: %v", searchPathPart)
+			}
+			searchPathString[i] = pq.QuoteIdentifier(searchPathPart.(string))
+		}
+	} else {
+		searchPathString = []string{"DEFAULT"}
+	}
+	searchPath := strings.Join(searchPathString[:], ", ")
+
+	log.Printf("[INFO] Altering PostgreSQL database (%q) search_path with: %s", dbName, searchPath)
+
+	query := fmt.Sprintf(
+		"ALTER DATABASE %s SET search_path TO %s", pq.QuoteIdentifier(dbName), searchPath,
+	)
+
+	log.Printf("[DEBUG] Altering PostgreSQL database (%q) search_path query: %s", dbName, query)
+
+	if _, err := db.Exec(query); err != nil {
+		return fmt.Errorf("could not set search_path %s for %s: %w", searchPath, dbName, err)
+	}
+
+	return nil
+}
+
 func doSetDBIsTemplate(db *DBConnection, dbName string, isTemplate bool) error {
 	if !db.featureSupported(featureDBIsTemplate) {
 		return fmt.Errorf("PostgreSQL client is talking with a server (%q) that does not support database IS_TEMPLATE", db.version.String())
@@ -642,4 +698,20 @@ func terminateBConnections(db *DBConnection, dbName string) error {
 	}
 
 	return nil
+}
+
+func getDBRoleSettings(db *DBConnection, dbId string) (pq.ByteaArray, error) {
+	var dbRoleConfigItems pq.ByteaArray
+	dbSQL := `SELECT setconfig FROM pg_catalog.pg_database AS d, pg_catalog.pg_db_role_setting AS drs  WHERE d.datname = $1 AND d.oid = drs.setdatabase AND setrole = 0`
+	err := db.QueryRow(dbSQL, dbId).Scan(&dbRoleConfigItems)
+
+	switch {
+	case err == sql.ErrNoRows:
+		log.Printf("[DEBUG] PostgreSQL database (%q) has no role settings", dbId)
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("error reading database role settings: %w", err)
+	}
+
+	return dbRoleConfigItems, nil
 }

--- a/postgresql/resource_postgresql_database_test.go
+++ b/postgresql/resource_postgresql_database_test.go
@@ -4,7 +4,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"reflect"
+	"sort"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -20,7 +23,7 @@ func TestAccPostgresqlDatabase_Basic(t *testing.T) {
 			{
 				Config: testAccPostgreSQLDatabaseConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlDatabaseExists("postgresql_database.mydb"),
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.mydb", nil),
 					resource.TestCheckResourceAttr(
 						"postgresql_database.mydb", "name", "mydb"),
 					resource.TestCheckResourceAttr(
@@ -85,6 +88,8 @@ func TestAccPostgresqlDatabase_Basic(t *testing.T) {
 						"postgresql_database.pathological_opts", "connection_limit", "0"),
 					resource.TestCheckResourceAttr(
 						"postgresql_database.pathological_opts", "is_template", "true"),
+					resource.TestCheckResourceAttr(
+						"postgresql_database.pathological_opts", "search_path.#", "0"),
 
 					resource.TestCheckResourceAttr(
 						"postgresql_database.pg_default_opts", "owner", "myrole"),
@@ -104,6 +109,8 @@ func TestAccPostgresqlDatabase_Basic(t *testing.T) {
 						"postgresql_database.pg_default_opts", "connection_limit", "0"),
 					resource.TestCheckResourceAttr(
 						"postgresql_database.pg_default_opts", "is_template", "true"),
+
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.mydb_search_path", []string{"bar", "foo-with-hyphen"}),
 				),
 			},
 		},
@@ -119,7 +126,7 @@ func TestAccPostgresqlDatabase_DefaultOwner(t *testing.T) {
 			{
 				Config: testAccPostgreSQLDatabaseConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlDatabaseExists("postgresql_database.mydb_default_owner"),
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.mydb_default_owner", nil),
 					resource.TestCheckResourceAttr(
 						"postgresql_database.mydb_default_owner", "name", "mydb_default_owner"),
 					resource.TestCheckResourceAttrSet(
@@ -158,10 +165,11 @@ func TestAccPostgresqlDatabase_Update(t *testing.T) {
 resource postgresql_database test_db {
     name = "test_db"
 	allow_connections = "%t"
+    search_path = ["searchpathInitial"]
 }
 `, allowConnections),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db", []string{"searchpathInitial"}),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", "test_db"),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "connection_limit", "-1"),
 					resource.TestCheckResourceAttr(
@@ -176,10 +184,11 @@ resource postgresql_database test_db {
 	name = "test_db"
 	connection_limit = 2
 	allow_connections = false
+	search_path = ["searchpathUpdated"]
 }
 	`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db", []string{"searchpathUpdated"}),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", "test_db"),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "connection_limit", "2"),
 					resource.TestCheckResourceAttr(
@@ -214,7 +223,7 @@ resource postgresql_database "test_db" {
 			{
 				Config: stateConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db", nil),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", "test_db"),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "owner", "test_owner"),
 
@@ -256,7 +265,7 @@ resource postgresql_database "test_db" {
 			{
 				Config: stateConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db", nil),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", "test_db"),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "owner", "test_owner"),
 
@@ -327,7 +336,7 @@ resource postgresql_database "test_db" {
 }
 `,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db", nil),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", databaseName),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "owner", new_owner),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "alter_object_ownership", "true"),
@@ -435,7 +444,7 @@ func testAccCheckPostgresqlDatabaseDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckPostgresqlDatabaseExists(n string) resource.TestCheckFunc {
+func testAccCheckPostgresqlDatabaseExists(n string, searchPath []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -457,6 +466,12 @@ func testAccCheckPostgresqlDatabaseExists(n string) resource.TestCheckFunc {
 			return errors.New("Db not found")
 		}
 
+		if searchPath != nil {
+			if err := checkDBSearchPath(client, rs.Primary.ID, searchPath); err != nil {
+				return fmt.Errorf("error checking db search_path %w", err)
+			}
+		}
+
 		return nil
 	}
 }
@@ -476,6 +491,49 @@ func checkDatabaseExists(client *Client, dbName string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func checkDBSearchPath(client *Client, dbName string, expectedSearchPath []string) error {
+	db, err := client.Connect()
+	if err != nil {
+		return err
+	}
+
+	var searchPathStr string
+	err = db.QueryRow(`
+		SELECT opts.option_value
+ 		FROM pg_catalog.pg_database AS d
+ 		JOIN pg_catalog.pg_db_role_setting AS drs ON d.oid = drs.setdatabase
+ 		CROSS JOIN LATERAL pg_options_to_table(drs.setconfig) AS opts
+ 		WHERE d.datname = $1 AND drs.setrole = 0 AND opts.option_name = 'search_path'`,
+		dbName,
+	).Scan(&searchPathStr)
+
+	// The query returns ErrNoRows if the search path hasn't been altered.
+	if err == sql.ErrNoRows {
+		searchPathStr = ""
+	} else if err != nil {
+		return fmt.Errorf("eror reading search_path: %v", err)
+	}
+
+	var searchPath []string
+	if searchPathStr != "" {
+		searchPath = strings.Split(searchPathStr, ", ")
+		for i := range searchPath {
+			searchPath[i] = strings.Trim(searchPath[i], `"`)
+		}
+	} else {
+		searchPath = []string{}
+	}
+	sort.Strings(searchPath)
+	sort.Strings(expectedSearchPath)
+	if !reflect.DeepEqual(searchPath, expectedSearchPath) {
+		return fmt.Errorf(
+			"search_path is not equal to expected value. expected %v - got %v",
+			expectedSearchPath, searchPath,
+		)
+	}
+	return nil
 }
 
 var testAccPostgreSQLDatabaseConfig = `
@@ -549,10 +607,16 @@ resource "postgresql_database" "pg_default_opts" {
   tablespace_name = "DEFAULT"
   connection_limit = 0
   is_template = true
+  search_path = []
 }
 
 resource "postgresql_database" "mydb_default_owner" {
    name = "mydb_default_owner"
+}
+
+resource "postgresql_database" "mydb_search_path" {
+   name = "mydb_search_path"
+   search_path = ["bar", "foo-with-hyphen"]
 }
 
 `

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -543,22 +543,6 @@ func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) er
 	return nil
 }
 
-// readSearchPath searches for a search_path entry in the rolconfig array.
-// In case no such value is present, it returns nil.
-func readSearchPath(roleConfig pq.ByteaArray) []string {
-	for _, v := range roleConfig {
-		config := string(v)
-		if strings.HasPrefix(config, roleSearchPathAttr) {
-			var result = strings.Split(strings.TrimPrefix(config, roleSearchPathAttr+"="), ", ")
-			for i := range result {
-				result[i] = strings.Trim(result[i], `"`)
-			}
-			return result
-		}
-	}
-	return nil
-}
-
 // readIdleInTransactionSessionTimeout searches for an idle_in_transaction_session_timeout entry in the rolconfig array.
 // In case no such value is present, it returns nil.
 func readIdleInTransactionSessionTimeout(roleConfig pq.ByteaArray) (int, error) {

--- a/website/docs/r/postgresql_database.html.markdown
+++ b/website/docs/r/postgresql_database.html.markdown
@@ -91,6 +91,10 @@ resource "postgresql_database" "my_db" {
   the database, you must be a direct or indirect member of the specified role, or
   the username in the provider must be superuser.
 
+* `search_path` - (Optional) Alters the search path of this new database. Note 
+  that due to limitations in the implementation, values cannot contain the 
+  substring `", "`.
+
 ## Import Example
 
 `postgresql_database` supports importing resources.  Supposing the following


### PR DESCRIPTION
In this PR I've added a `search_path` parameter on the `postgresql_database` resource, which allows to alter the database to set a value for its search path. 

It's inspired from what has been done by on the role (the `readSearchPath` function has been moved in `helpers.go` as I've re-used it. 

Web documentation has been updated as well 🙂 