### PR TITLE
Create roles with Azure managed identities in Azure PostgreSQL Flexible Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ make testacc_cleanup
 The Azure identity role test can only run against an actual Azure postgres instance, also only a Microsoft Entra administrator is allowed to manage Microsoft Entra roles
 In order to run the Azure identity test, run the following commands:
 ```sh
-source tests/
+source tests/switch_azure_ad_user.sh
 
 TF_LOG=INFO go test -v ./postgresql -run ^TestAccPostgresqlRole_AzureIdentity
 ```

--- a/README.md
+++ b/README.md
@@ -79,3 +79,11 @@ TF_LOG=INFO go test -v ./postgresql -run ^TestAccPostgresqlRole_Basic$
 # cleans the env and tears down the postgres container
 make testacc_cleanup 
 ```
+
+The Azure identity role test can only run against an actual Azure postgres instance, also only a Microsoft Entra administrator is allowed to manage Microsoft Entra roles
+In order to run the Azure identity test, run the following commands:
+```sh
+source tests/
+
+TF_LOG=INFO go test -v ./postgresql -run ^TestAccPostgresqlRole_AzureIdentity
+```

--- a/tests/switch_azure_ad_user.sh
+++ b/tests/switch_azure_ad_user.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export TF_ACC=true
+export PGHOST=<some-flexible-server>.postgres.database.azure.com
+export PGPORT=5432
+export PGUSER=azure
+export PGPASSWORD=$(az account get-access-token --resource-type oss-rdbms --query "[accessToken]" -o tsv)
+export PGSSLMODE=require
+export PGSUPERUSER=false
+export AZURE=true

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -118,6 +118,10 @@ resource "postgresql_role" "my_replication_role" {
 
 * `assume_role` - (Optional) Defines the role to switch to at login via [`SET ROLE`](https://www.postgresql.org/docs/current/sql-set-role.html).
 
+* `azure_identity_id` - (Optional) Unique object identifier of the Microsoft Entra object. See [how to manage azure ad users](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-manage-azure-ad-users) for more details.
+
+* `azure_identity_type` - (Optional) Type of the Microsoft Entra object to link to this role: service, user or group.
+
 ## Import Example
 
 `postgresql_role` supports importing resources.  Supposing the following


### PR DESCRIPTION
This is an Azure (PostgreSQL Flexible Server) specific addition to the role resource which allows to create roles and "assign" to them an Azure managed identity.

More details can be found here: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-manage-azure-ad-users 

Note: there are some additional features available like setting an admin or MFA flag which can be added easily if there is demand, but are left out to keep this PR and the list of options clean for now.