### PR TITLE
Support IAM auth for gcp

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -244,11 +244,17 @@ func (c *Config) connStr(database string) string {
 		host = strings.ReplaceAll(host, ":", "/")
 	}
 
+	var userInfo string
+	if c.Password == "" {
+		userInfo = url.PathEscape(c.Username)
+	} else {
+		userInfo = fmt.Sprintf("%s:%s", url.PathEscape(c.Username), url.PathEscape(c.Password))
+	}
+
 	connStr := fmt.Sprintf(
-		"%s://%s:%s@%s:%d/%s?%s",
+		"%s://%s@%s:%d/%s?%s",
 		c.Scheme,
-		url.PathEscape(c.Username),
-		url.PathEscape(c.Password),
+		userInfo,
 		host,
 		c.Port,
 		database,


### PR DESCRIPTION
The GoCloud connector used to connect to CloudSQL now has support for IAM auth. This PR aims to update the provider to also support IAM auth.

The only change that needs to be made is removing the `:` in `username:password` part of the string if the password is not set.