### PR TITLE
Added a check during the `postgresql_extension` to prevent multiple resources from being created for the one schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,22 @@ TF_LOG=INFO go test -v ./postgresql -run ^TestAccPostgresqlRole_Basic$
 # cleans the env and tears down the postgres container
 make testacc_cleanup 
 ```
+
+Testing the provider in a Terraform project
+---------------------------
+
+To have terraform source from your local version of the provider, ensure you have completed the [above steps](#developing-the-provider) including cloning the provider into your `$GOPATH/src/github.com/cyrilgdn/terraform-provider-postgresql` and running `make build`. Once complete, you can configure your `~/.terraformrc` file with the below config.
+
+```hcl2
+# .terraformrc
+provider_installation {
+  
+  dev_overrides {
+    "cyrilgdn/postgresql" = "{YOUR $GOPATH}/bin"
+  }
+
+  direct {}
+}
+```
+
+For more information on this configuration, [view the docs on Terraform website](https://developer.hashicorp.com/terraform/cli/config/config-file#cli-configuration-file-terraformrc-or-terraform-rc)

--- a/website/docs/r/postgresql_extension.html.markdown
+++ b/website/docs/r/postgresql_extension.html.markdown
@@ -8,8 +8,7 @@ description: |-
 
 # postgresql\_extension
 
-The ``postgresql_extension`` resource creates and manages an extension on a PostgreSQL
-server.
+The ``postgresql_extension`` resource creates and manages an [extension](https://www.postgresql.org/docs/current/sql-createextension.html) on a PostgreSQL server. Only one `postgresql_extension` of each `name` should exist per database.
 
 
 ## Usage
@@ -23,7 +22,7 @@ resource "postgresql_extension" "my_extension" {
 ## Argument Reference
 
 * `name` - (Required) The name of the extension.
-* `schema` - (Optional) Sets the schema of an extension.
+* `schema` - (Optional) Sets the schema in which to install the extension's objects
 * `version` - (Optional) Sets the version number of the extension.
 * `database` - (Optional) Which database to create the extension on. Defaults to provider database.
 * `drop_cascade` - (Optional) When true, will also drop all the objects that depend on the extension, and in turn all objects that depend on those objects. (Default: false)


### PR DESCRIPTION
To address [#304] where users are implementing multiple extension resources per extension under the assumption one is required per schema. According to postgres documentation, schema is only the location to install the extensions objects.

Changes:
- Updated the README to describe running the provider in a local environment
- Added a check during the `postgresql_extension` to prevent multiple resources from being created for the one schema
- Updated documentation to deter users from creating the same extension across multiple schemas

Projects which contain multiple resources for the same extension will still experience the same behaviour akin to importing a resource into two places. However, new resources created will be unable to do so if the extension exists. A note in the upgrade docs should mention to `terraform state rm` places where extensions have been duplicated