### PR TITLE
Add support for view resource 

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -41,6 +41,7 @@ const (
 	featurePubWithoutTruncate
 	featureFunction
 	featureServer
+	featureView
 )
 
 var (
@@ -112,6 +113,8 @@ var (
 		featureServer: semver.MustParseRange(">=10.0.0"),
 
 		featureDatabaseOwnerRole: semver.MustParseRange(">=15.0.0"),
+
+		featureView: semver.MustParseRange(">12.0.0"),
 	}
 )
 

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -3,9 +3,10 @@ package postgresql
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"os"
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -199,6 +200,7 @@ func Provider() *schema.Provider {
 			"postgresql_function":                  resourcePostgreSQLFunction(),
 			"postgresql_server":                    resourcePostgreSQLServer(),
 			"postgresql_user_mapping":              resourcePostgreSQLUserMapping(),
+			"postgresql_view":                      resourcePostgreSQLView(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/postgresql/resource_postgresql_view.go
+++ b/postgresql/resource_postgresql_view.go
@@ -1,0 +1,102 @@
+package postgresql
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	viewNameAttr        = "name"
+	viewSchemaAttr      = "schema"
+	viewRecursiveAttr   = "recursive"
+	viewColumnNamesAttr = "column_names"
+	viewBodyAttr        = "body"
+	viewCheckOptionAttr = "check_option"
+)
+
+func resourcePostgreSQLView() *schema.Resource {
+	return &schema.Resource{
+		Create: PGResourceFunc(resourcePostgreSQLViewCreate),
+		Read:   PGResourceFunc(resourcePostgreSQLViewCreate),
+		Update: PGResourceFunc(resourcePostgreSQLViewCreate),
+		Delete: PGResourceFunc(resourcePostgreSQLViewCreate),
+		Exists: PGResourceExistsFunc(resourcePostgreSQLFunctionExists),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			viewSchemaAttr: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Schema where the view is located. If not specified, the provider default is used.",
+
+				DiffSuppressFunc: defaultDiffSuppressFunc,
+			},
+			viewNameAttr: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the view.",
+			},
+			viewRecursiveAttr: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If the view is a recursive view.",
+			},
+			viewColumnNamesAttr: {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The optional list of names to be used for columns of the view. If not given, the column names are deduced from the query.",
+			},
+			viewBodyAttr: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Body of the view.",
+
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return normalizeFunctionBody(new) == old
+				},
+				StateFunc: func(val interface{}) string {
+					return normalizeFunctionBody(val.(string))
+				},
+			},
+			viewCheckOptionAttr: {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: defaultDiffSuppressFunc,
+				ValidateFunc:     validation.StringInSlice([]string{"CASCADED", "LOCAL"}, true),
+				Description:      "Controls the behavior of automatically updatable views. One of: CASCADED, LOCAL",
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLViewCreate(db *DBConnection, d *schema.ResourceData) error {
+	if !db.featureSupported(featureFunction) {
+		return fmt.Errorf(
+			"postgresql_view resource is not supported for this Postgres version (%s)",
+			db.version,
+		)
+	}
+
+	if err := createView(db, d, false); err != nil {
+		return err
+	}
+
+	return resourcePostgreSQLViewReadImpl(db, d)
+}
+
+func resourcePostgreSQLViewReadImpl(db *DBConnection, d *schema.ResourceData) error {
+	return nil
+}
+
+func createView(db *DBConnection, d *schema.ResourceData, replace bool) error {
+	return nil
+}

--- a/postgresql/resource_postgresql_view.go
+++ b/postgresql/resource_postgresql_view.go
@@ -1,18 +1,23 @@
 package postgresql
 
 import (
+	"bytes"
+	"database/sql"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/lib/pq"
 )
 
 const (
 	viewNameAttr        = "name"
 	viewSchemaAttr      = "schema"
+	viewDatabaseAttr    = "database"
 	viewRecursiveAttr   = "recursive"
 	viewColumnNamesAttr = "column_names"
-	viewBodyAttr        = "body"
+	viewQueryAttr       = "query"
 	viewCheckOptionAttr = "check_option"
 )
 
@@ -28,12 +33,21 @@ func resourcePostgreSQLView() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			viewDatabaseAttr: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The database where the view is located. If not specified, the provider default database is used.",
+
+				DiffSuppressFunc: defaultDiffSuppressFunc,
+			},
 			viewSchemaAttr: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: "Schema where the view is located. If not specified, the provider default is used.",
+				Description: "The schema where the view is located. If not specified, the provider default is used.",
 
 				DiffSuppressFunc: defaultDiffSuppressFunc,
 			},
@@ -41,7 +55,7 @@ func resourcePostgreSQLView() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Name of the view.",
+				Description: "The name of the view.",
 			},
 			viewRecursiveAttr: {
 				Type:        schema.TypeBool,
@@ -50,15 +64,15 @@ func resourcePostgreSQLView() *schema.Resource {
 				Description: "If the view is a recursive view.",
 			},
 			viewColumnNamesAttr: {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The optional list of names to be used for columns of the view. If not given, the column names are deduced from the query.",
 			},
-			viewBodyAttr: {
+			viewQueryAttr: {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Body of the view.",
+				Description: "The query of the view.",
 
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return normalizeFunctionBody(new) == old
@@ -72,7 +86,7 @@ func resourcePostgreSQLView() *schema.Resource {
 				Optional:         true,
 				DiffSuppressFunc: defaultDiffSuppressFunc,
 				ValidateFunc:     validation.StringInSlice([]string{"CASCADED", "LOCAL"}, true),
-				Description:      "Controls the behavior of automatically updatable views. One of: CASCADED, LOCAL",
+				Description:      "The check option which controls the behavior of automatically updatable views. One of: CASCADED, LOCAL",
 			},
 		},
 	}
@@ -94,9 +108,146 @@ func resourcePostgreSQLViewCreate(db *DBConnection, d *schema.ResourceData) erro
 }
 
 func resourcePostgreSQLViewReadImpl(db *DBConnection, d *schema.ResourceData) error {
+	viewID := d.Id()
+	if viewID == "" {
+		genViewID, err := genViewID(db, d)
+		if err != nil {
+			return err
+		}
+		viewID = genViewID
+	}
+
+	// Query the view definition
+	databaseName := db.client.databaseName
+	if databaseAttr, ok := d.GetOk(viewDatabaseAttr); ok {
+		databaseName = databaseAttr.(string)
+	}
+
+	query := ``
+	txn, err := startTransaction(db.client, databaseName)
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	var viewQuery string
+	err = txn.QueryRow(query).Scan(&viewQuery)
+	switch {
+	case err == sql.ErrNoRows:
+		log.Printf("[WARN] PostgreSQL view: %s", viewID)
+		d.SetId("")
+		return nil
+	case err != nil:
+		return fmt.Errorf("Error reading view: %w", err)
+	}
+
+	if err := txn.Commit(); err != nil {
+		return err
+	}
+
+	d.Set(viewDatabaseAttr, databaseName)
+	d.Set(viewSchemaAttr, "")
+	d.Set(viewNameAttr, "")
+	d.Set(viewRecursiveAttr, false)
+	d.Set(viewColumnNamesAttr, "")
+	d.Set(viewQuery, "")
+	d.Set(viewCheckOptionAttr, "")
+
+	d.SetId(viewID)
+
 	return nil
 }
 
+func genViewID(db *DBConnection, d *schema.ResourceData) (string, error) {
+	// Generate with format: <database_name>.<schema_name>.<view_name>
+	b := bytes.NewBufferString("")
+	if databaseAttr, ok := d.GetOk(viewDatabaseAttr); ok {
+		fmt.Fprint(b, databaseAttr.(string), ".")
+	} else {
+		fmt.Fprint(b, db.client.databaseName, ".")
+	}
+
+	schemaName := "public"
+	if v, ok := d.GetOk(viewSchemaAttr); ok {
+		schemaName = v.(string)
+	}
+	viewName := d.Get(viewNameAttr).(string)
+
+	fmt.Fprint(b, schemaName, ".", viewName)
+	return b.String(), nil
+}
+
 func createView(db *DBConnection, d *schema.ResourceData, replace bool) error {
+	schemaName := "public"
+	if v, ok := d.GetOk(viewSchemaAttr); ok {
+		schemaName = v.(string)
+	}
+
+	name := d.Get(viewNameAttr).(string)
+	recursive := false
+	if v, ok := d.GetOk(viewRecursiveAttr); ok {
+		recursive = v.(bool)
+	}
+
+	var columnNames []string
+	if v, ok := d.GetOk(viewColumnNamesAttr); ok {
+		columnNames = v.([]string)
+	}
+
+	query := d.Get(viewQueryAttr).(string)
+
+	var checkOption string
+	if v, ok := d.GetOk(viewCheckOptionAttr); ok {
+		checkOption = v.(string)
+	}
+
+	// Construct the view
+	b := bytes.NewBufferString("CREATE ")
+	if replace {
+		b.WriteString("OR REPLACE ")
+	}
+
+	if recursive {
+		b.WriteString("RECURSIVE ")
+	}
+	b.WriteString("VIEW ")
+
+	fmt.Fprint(b, pq.QuoteIdentifier(schemaName), ".")
+	fmt.Fprint(b, pq.QuoteIdentifier(name))
+
+	for idx, columnName := range columnNames {
+		if idx <= 0 {
+			b.WriteRune('(')
+		}
+		if idx > 0 {
+			b.WriteRune(',')
+		}
+		b.WriteString(columnName)
+	}
+	if len(columnNames) > 0 {
+		b.WriteRune(')')
+	}
+
+	fmt.Fprint(b, " AS\n", query)
+	if checkOption == "" {
+		fmt.Fprint(b, "\nWITH ", checkOption, " CHECK OPTION")
+	}
+	b.WriteRune(';')
+
+	sql := b.String()
+	txn, err := startTransaction(db.client, d.Get(viewDatabaseAttr).(string))
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	if _, err := txn.Exec(sql); err != nil {
+		return err
+	}
+
+	if err := txn.Commit(); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/postgresql/resource_postgresql_view_test.go
+++ b/postgresql/resource_postgresql_view_test.go
@@ -3,6 +3,7 @@ package postgresql
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,28 +14,29 @@ func TestAccPostgresqlView_Basic(t *testing.T) {
 	config := `
 resource "postgresql_view" "basic_view" {
     name = "basic_view"
-    query = "SELECT * FROM tableA"
+    query = <<-EOF
+		SELECT *
+		FROM unnest(ARRAY[1]) AS element;
+	EOF
 }
 `
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testCheckCompatibleVersion(t, featureFunction)
+			testCheckCompatibleVersion(t, featureView)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPostgresqlFunctionDestroy,
+		CheckDestroy: testAccCheckPostgresqlViewDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPostgresqlViewExists("postgresql_view.basic_view", ""),
 					resource.TestCheckResourceAttr(
-						"ppostgresql_view.basic_view", "schema", "public"),
+						"postgresql_view.basic_view", "schema", "public"),
 					resource.TestCheckResourceAttr(
 						"postgresql_view.basic_view", "name", "basic_view"),
-					resource.TestCheckResourceAttr(
-						"postgresql_view.basic_view", "query", "SELECT * FROM tableA"),
 					resource.TestCheckResourceAttr(
 						"postgresql_view.basic_view", "with_check_option", ""),
 					resource.TestCheckResourceAttr(
@@ -49,13 +51,176 @@ resource "postgresql_view" "basic_view" {
 	})
 }
 
-func TestAccPostgresqlFunction_SpecificDatabase(t *testing.T) {
+func TestAccPostgresqlView_SpecificDatabase(t *testing.T) {
 	skipIfNotAcc(t)
 
 	dbSuffix, teardown := setupTestDatabase(t, true, true)
 	defer teardown()
 
 	dbName, _ := getTestDBNames(dbSuffix)
+
+	config := `
+resource "postgresql_view" "basic_view" {
+	database = "%s"
+	schema = "test_schema"
+	name = "basic_view"
+	query = <<-EOF
+		SELECT *
+		FROM unnest(ARRAY[1]) AS element;
+	EOF
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureView)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlViewDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(config, dbName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlViewExists("postgresql_view.basic_view", dbName),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "database", dbName),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "schema", "test_schema"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "name", "basic_view"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "with_check_option", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlView_AllOptions(t *testing.T) {
+	skipIfNotAcc(t)
+
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+
+	dbName, _ := getTestDBNames(dbSuffix)
+
+	config := `
+resource "postgresql_view" "all_option_view" {
+	database = "%s"
+	schema = "test_schema"
+	name = "all_option_view"
+	query = <<-EOF
+		SELECT schemaname, tablename
+		FROM pg_catalog.pg_tables;
+	EOF
+	with_check_option = "CASCADED"
+	with_security_barrier = true
+	with_security_invoker = true
+	drop_cascade = true
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureView)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlViewDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(config, dbName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlViewExists("postgresql_view.all_option_view", dbName),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.all_option_view", "database", dbName),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.all_option_view", "schema", "test_schema"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.all_option_view", "name", "all_option_view"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.all_option_view", "with_check_option", "CASCADED"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.all_option_view", "with_security_barrier", "true"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.all_option_view", "with_security_invoker", "true"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.all_option_view", "drop_cascade", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlView_Update(t *testing.T) {
+	configCreate := `
+resource "postgresql_view" "pg_view" {
+    name = "pg_view"
+	query = <<-EOF
+		SELECT schemaname, tablename
+		FROM pg_catalog.pg_tables;
+	EOF
+}
+`
+
+	configUpdate := `
+resource "postgresql_view" "pg_view" {
+	name = "pg_view"
+	query = <<-EOF
+		SELECT schemaname, tablename, tableowner
+		FROM pg_catalog.pg_tables;
+	EOF
+	with_check_option = "CASCADED"
+	with_security_barrier = true
+	with_security_invoker = true
+	drop_cascade = true
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureView)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlViewDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlViewExists("postgresql_view.pg_view", ""),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "schema", "public"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "name", "pg_view"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "with_check_option", ""),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "with_security_barrier", "false"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "with_security_invoker", "false"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "drop_cascade", "false"),
+				),
+			},
+			{
+				Config: configUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlViewExists("postgresql_view.pg_view", ""),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "schema", "public"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "name", "pg_view"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "with_check_option", "CASCADED"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "with_security_barrier", "true"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "with_security_invoker", "true"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.pg_view", "drop_cascade", "true"),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckPostgresqlViewExists(n string, database string) resource.TestCheckFunc {
@@ -78,18 +243,50 @@ func testAccCheckPostgresqlViewExists(n string, database string) resource.TestCh
 		}
 		defer deferredRollback(txn)
 
-		exists, err := checkFunctionExists(txn, signature)
+		exists, err := checkViewExists(txn, signature)
 
 		if err != nil {
 			return fmt.Errorf("Error checking function %s", err)
 		}
 
 		if !exists {
-			return fmt.Errorf("Function not found")
+			return fmt.Errorf("View not found")
 		}
 
 		return nil
 	}
+}
+
+func testAccCheckPostgresqlViewDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "postgresql_view" {
+			continue
+		}
+
+		txn, err := startTransaction(client, "")
+		if err != nil {
+			return err
+		}
+		defer deferredRollback(txn)
+
+		viewParts := strings.Split(rs.Primary.ID, ".")
+		_, schemaName, viewName := viewParts[0], viewParts[1], viewParts[2]
+		viewIdentifier := fmt.Sprintf("%s.%s", schemaName, viewName)
+
+		exists, err := checkViewExists(txn, viewIdentifier)
+
+		if err != nil {
+			return fmt.Errorf("Error checking view %s", err)
+		}
+
+		if exists {
+			return fmt.Errorf("View still exists after destroy")
+		}
+	}
+
+	return nil
 }
 
 func checkViewExists(txn *sql.Tx, signature string) (bool, error) {

--- a/postgresql/resource_postgresql_view_test.go
+++ b/postgresql/resource_postgresql_view_test.go
@@ -1,0 +1,106 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccPostgresqlView_Basic(t *testing.T) {
+	config := `
+resource "postgresql_view" "basic_view" {
+    name = "basic_view"
+    query = "SELECT * FROM tableA"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureFunction)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlViewExists("postgresql_view.basic_view", ""),
+					resource.TestCheckResourceAttr(
+						"ppostgresql_view.basic_view", "schema", "public"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "name", "basic_view"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "query", "SELECT * FROM tableA"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "with_check_option", ""),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "with_security_barrier", "false"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "with_security_invoker", "false"),
+					resource.TestCheckResourceAttr(
+						"postgresql_view.basic_view", "drop_cascade", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlFunction_SpecificDatabase(t *testing.T) {
+	skipIfNotAcc(t)
+
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+
+	dbName, _ := getTestDBNames(dbSuffix)
+}
+
+func testAccCheckPostgresqlViewExists(n string, database string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		signature := rs.Primary.ID
+
+		client := testAccProvider.Meta().(*Client)
+		txn, err := startTransaction(client, database)
+		if err != nil {
+			return err
+		}
+		defer deferredRollback(txn)
+
+		exists, err := checkFunctionExists(txn, signature)
+
+		if err != nil {
+			return fmt.Errorf("Error checking function %s", err)
+		}
+
+		if !exists {
+			return fmt.Errorf("Function not found")
+		}
+
+		return nil
+	}
+}
+
+func checkViewExists(txn *sql.Tx, signature string) (bool, error) {
+	var _rez bool
+	err := txn.QueryRow(fmt.Sprintf("SELECT to_regclass('%s') IS NOT NULL", signature)).Scan(&_rez)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("Error reading info about view: %s", err)
+	}
+
+	return _rez, nil
+}

--- a/website/docs/r/postgresql_view.html.markdown
+++ b/website/docs/r/postgresql_view.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "postgresql"
+page_title: "PostgreSQL: postgresql_view"
+sidebar_current: "docs-postgresql-resource-postgresql_view"
+description: |-
+Creates and manages a view on a PostgreSQL server.
+---
+
+# postgresql_view
+
+The `postgresql_view` resource creates and manages a view on a PostgreSQL server.
+
+## Usage
+
+```hcl
+resource "postgresql_view" "aggregation_view" {
+    database  = "database_name"
+    schema = "schema_name"
+    name = "aggregation_view"
+    query = <<-EOF
+      SELECT schemaname, tablename
+      FROM pg_catalog.pg_tables;
+    EOF
+    with_check_option = "CASCADED"
+    with_security_barrier = true
+    with_security_invoker = true
+    drop_cascade = true
+}
+```
+
+## Argument Reference
+
+- `database` - (Optional) The database where the view is located.
+  If not specified, the view is created in the current database.
+
+- `schema` - (Optional) The schema where the view is located.
+  If not specified, the view is created in the current schema.
+
+- `name` - (Required) The name of the view.
+
+- `query` - (Required) The query.
+
+- `with_check_option` - (Optional) The check option which controls the behavior
+  of automatically updatable views. One of: CASCADED, LOCAL.
+
+- `with_security_barrier` - (Optional) This should be used if the view is intended to provide row-level security.
+
+- `with_security_invoker` - (Optional) This option causes the underlying base relations to be
+  checked against the privileges of the user of the view rather than the view owner.
+
+- `drop_cascade` - (Optional) - True tp automatically drop objects that depend on the view (such as other views),
+  and in turn all objects that depend on those objects. Default is false.
+
+## Postgres documentation
+
+- https://www.postgresql.org/docs/16/sql-createview.html

--- a/website/docs/r/postgresql_view.html.markdown
+++ b/website/docs/r/postgresql_view.html.markdown
@@ -41,12 +41,12 @@ resource "postgresql_view" "aggregation_view" {
 - `query` - (Required) The query.
 
 - `with_check_option` - (Optional) The check option which controls the behavior
-  of automatically updatable views. One of: CASCADED, LOCAL.
+  of automatically updatable views. One of: CASCADED, LOCAL. Default is not set.
 
-- `with_security_barrier` - (Optional) This should be used if the view is intended to provide row-level security.
+- `with_security_barrier` - (Optional) This should be used if the view is intended to provide row-level security. Default is false.
 
 - `with_security_invoker` - (Optional) This option causes the underlying base relations to be
-  checked against the privileges of the user of the view rather than the view owner.
+  checked against the privileges of the user of the view rather than the view owner. Default is false.
 
 - `drop_cascade` - (Optional) - True tp automatically drop objects that depend on the view (such as other views),
   and in turn all objects that depend on those objects. Default is false.


### PR DESCRIPTION
This PR adds support for views in the provider. 

Features:
- Manages Postgres views: create/update/delete.
- Supports all view's options: check_option, security_barrier, security_invoker.

_Notes_: This PR is only for regular views, materialized views deserve a separate resource type. eg: _postgresql_materialized_view_

Please let me know if you see any issues!



