### PR TITLE
provider: set aws_rds_iam_region even if aws_rds_iam_profile is set

### DIFF
--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -226,13 +226,14 @@ func getRDSAuthToken(region string, profile string, username string, host string
 	var awscfg aws.Config
 	var err error
 
+	loadOptions := []func(*awsConfig.LoadOptions) error{}
 	if profile != "" {
-		awscfg, err = awsConfig.LoadDefaultConfig(ctx, awsConfig.WithSharedConfigProfile(profile))
-	} else if region != "" {
-		awscfg, err = awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(region))
-	} else {
-		awscfg, err = awsConfig.LoadDefaultConfig(ctx)
+		loadOptions = append(loadOptions, awsConfig.WithSharedConfigProfile(profile))
 	}
+	if region != "" {
+		loadOptions = append(loadOptions, awsConfig.WithRegion(region))
+	}
+	awscfg, err = awsConfig.LoadDefaultConfig(ctx, loadOptions...)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
this fixes #444 

tested to ensure that this works as intended