### PR TITLE
Add support for Azure China & Government Cloud

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/lib/pq"
 )
@@ -686,4 +687,20 @@ func quoteTableName(tableName string) string {
 		parts[i] = pq.QuoteIdentifier(parts[i])
 	}
 	return strings.Join(parts, ".")
+}
+
+func cloudConfigFromName(name string) (cloud.Configuration, error) {
+	switch strings.ToLower(name) {
+	case "china":
+		return cloud.AzureChina, nil
+
+	case "usgovernment":
+		return cloud.AzureGovernment, nil
+
+	case "public":
+		return cloud.AzurePublic, nil
+
+	default:
+		return cloud.Configuration{}, fmt.Errorf("unsupported Azure Cloud environment: %s", name)
+	}
 }

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -3,27 +3,40 @@ package postgresql
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/blang/semver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"golang.org/x/oauth2/google"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsConfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 )
 
 const (
-	defaultProviderMaxOpenConnections = 20
-	defaultExpectedPostgreSQLVersion  = "9.0.0"
+	defaultProviderMaxOpenConnections                   = 20
+	defaultExpectedPostgreSQLVersion                    = "9.0.0"
+	serviceName                       cloud.ServiceName = "ossrdbms-aad"
 )
+
+func init() {
+	cloud.AzureChina.Services[serviceName] = cloud.ServiceConfiguration{
+		Audience: "https://ossrdbms-aad.database.chinacloudapi.cn",
+	}
+	cloud.AzureGovernment.Services[serviceName] = cloud.ServiceConfiguration{
+		Audience: "https://ossrdbms-aad.database.usgovcloudapi.net",
+	}
+	cloud.AzurePublic.Services[serviceName] = cloud.ServiceConfiguration{
+		Audience: "https://ossrdbms-aad.database.windows.net",
+	}
+}
 
 // Provider returns a terraform.ResourceProvider.
 func Provider() *schema.Provider {
@@ -104,6 +117,14 @@ func Provider() *schema.Provider {
 				Optional: true,
 				Description: "Use MS Azure identity OAuth token " +
 					"(see: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-configure-sign-in-azure-ad-authentication)",
+			},
+
+			"azure_environment": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "public",
+				ValidateFunc: validation.StringInSlice([]string{"public", "usgovernment", "china"}, false),
+				Description:  "MS Azure Cloud environment (see: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#environment)",
 			},
 
 			"azure_tenant_id": {
@@ -314,14 +335,25 @@ func createGoogleCredsFileIfNeeded() error {
 	return os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", tmpFile.Name())
 }
 
-func acquireAzureOauthToken(tenantId string) (string, error) {
+func acquireAzureOauthToken(environment, tenantId string) (string, error) {
+	cloudConfig, err := cloudConfigFromName(environment)
+	if err != nil {
+		return "", err
+	}
 	credential, err := azidentity.NewDefaultAzureCredential(
-		&azidentity.DefaultAzureCredentialOptions{TenantID: tenantId})
+		&azidentity.DefaultAzureCredentialOptions{
+			ClientOptions: azcore.ClientOptions{
+				Cloud: cloudConfig,
+			},
+			TenantID: tenantId,
+		})
 	if err != nil {
 		return "", err
 	}
 	token, err := credential.GetToken(context.Background(), policy.TokenRequestOptions{
-		Scopes:   []string{"https://ossrdbms-aad.database.windows.net/.default"},
+		Scopes: []string{
+			cloudConfig.Services[serviceName].Audience + "/.default",
+		},
 		TenantID: tenantId,
 	})
 	if err != nil {
@@ -358,12 +390,13 @@ func providerConfigure(d *schema.ResourceData) (any, error) {
 			return nil, err
 		}
 	} else if d.Get("azure_identity_auth").(bool) {
+		environment := d.Get("azure_environment").(string)
 		tenantId := d.Get("azure_tenant_id").(string)
 		if tenantId == "" {
 			return nil, fmt.Errorf("postgresql: azure_identity_auth is enabled, azure_tenant_id must be provided also")
 		}
 		var err error
-		password, err = acquireAzureOauthToken(tenantId)
+		password, err = acquireAzureOauthToken(environment, tenantId)
 		if err != nil {
 			return nil, err
 		}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -186,6 +186,7 @@ The following arguments are supported:
 * `aws_rds_iam_provider_role_arn` - (Optional) AWS IAM role to assume while using AWS RDS IAM Auth.
 * `azure_identity_auth` - (Optional) If set to `true`, call the Azure OAuth token endpoint for temporary token
 * `azure_tenant_id` - (Optional) (Required if `azure_identity_auth` is `true`) Azure tenant ID [read more](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config.html)
+* `azure_environment` - (Optional) The Azure Cloud environment. Possible values are `public`, `usgovernment` and `china`. Defaults to `public`.
 
 ## GoCloud
 


### PR DESCRIPTION
This PR adds support for Azure China & Government Cloud for passwordless authentication.

I have checked this change with AzureCLI credentials and service principles in Azure Public and Azure China Cloud.

Please let me know if you see any issues and I will be happy to fix them.

<sup>Felix Furrer [felix.furrer@mercedes-benz.com](mailto:felix.furrer@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)</sup>