### PR TITLE
Add support for adding comments to PostgreSQL roles

### DIFF
--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -58,6 +58,10 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.sub_role", "roles.1", "role_simple"),
 
 					testAccCheckPostgresqlRoleExists("role_with_search_path", nil, []string{"bar", "foo-with-hyphen"}),
+
+					testAccCheckPostgresqlRoleExists("role_with_comment", nil, nil),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_comment", "name", "role_with_comment"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_comment", "comment", "This is a test comment"),
 				),
 			},
 		},
@@ -104,6 +108,7 @@ resource "postgresql_role" "update_role" {
   login = true
   password = "toto"
   valid_until = "2099-05-04 12:00:00+00"
+  comment = "Initial comment"
 }
 `
 
@@ -122,6 +127,7 @@ resource "postgresql_role" "update_role" {
   statement_timeout = 30000
   idle_in_transaction_session_timeout = 60000
   assume_role = "${postgresql_role.group_role.name}"
+  comment = "Updated comment"
 }
 `
 	resource.Test(t, resource.TestCase{
@@ -146,6 +152,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "comment", "Initial comment"),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -167,6 +174,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "30000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "60000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", "group_role"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "comment", "Updated comment"),
 					testAccCheckRoleCanLogin(t, "update_role2", "titi"),
 				),
 			},
@@ -185,6 +193,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "comment", "Initial comment"),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -436,5 +445,10 @@ resource "postgresql_role" "sub_role" {
 resource "postgresql_role" "role_with_search_path" {
   name = "role_with_search_path"
   search_path = ["bar", "foo-with-hyphen"]
+}
+
+resource "postgresql_role" "role_with_comment" {
+  name = "role_with_comment"
+  comment = "This is a test comment"
 }
 `


### PR DESCRIPTION
### Summary

This PR adds support for attaching comments to PostgreSQL roles, allowing users to document the purpose of each role within the database. This improves clarity and supports compliance requirements.

### Use Case

Teams managing PostgreSQL roles across environments can add comments to provide context or document role policies, aiding in audits and compliance.

### Example

```
resource "postgresql_role" "my_role" {
  name     = "my_role"
  login    = true
  password = "mypass"
  comment  = "Role created for application access (JIRA: PROJ-1234)"
}
```