### PR TITLE
fix(postgresql_role): Postgresql 16 compatibility (with new roles man…

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.23.x
 
       - run: go mod vendor
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53
+          version: v1.61

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.20'
+          go-version: '1.23'
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        pgversion: [15, 14, 13, 12, 11]
+        pgversion: [16, 15, 14, 13, 12, 11]
 
     env:
       PGVERSION: ${{ matrix.pgversion }}
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.23'
 
       - name: test
         run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,149 @@
-./*.tfstate
-.terraform/
-.terraform.lock.hcl*
-*.log
-.*.swp
-tests/docker-compose.*.yml
 terraform-provider-postgresql
+
+### JetBrains+all template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Go template
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+.terraform
+.terraform.lock.hcl
+terraform.tfstate*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
--	[Go](https://golang.org/doc/install) 1.16 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.21 (to build the provider plugin)
 
 Building The Provider
 ---------------------

--- a/examples/issues/407/dev.tfrc
+++ b/examples/issues/407/dev.tfrc
@@ -1,0 +1,13 @@
+# See https://www.terraform.io/cli/config/config-file#development-overrides-for-provider-developers
+# Use `go build -o ./examples/issues/407/postgresql/terraform-provider-postgresql` in the project root to build the provider.
+# Then run terraform in this example directory.
+
+# terraform init
+# TF_CLI_CONFIG_FILE=dev.tfrc terraform apply
+
+provider_installation {
+  dev_overrides {
+    "cyrilgdn/postgresql" = "./postgresql"
+  }
+  direct {}
+}

--- a/examples/issues/407/test.tf
+++ b/examples/issues/407/test.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "~>1"
+    }
+  }
+}
+
+provider "postgresql" {
+  superuser = false
+  port      = 25432
+  username  = "rds"
+  password  = "rds"
+  sslmode   = "disable"
+}
+
+resource "postgresql_role" "test_role_with_createrole_self_grant" {
+  name                  = "test_role_with_createrole_self_grant"
+  parameters {
+    createrole_self_grant = "set,inherit"
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-providers/terraform-provider-postgresql
 
-go 1.20
+go 1.23
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -44,6 +44,7 @@ const (
 	featurePubWithoutTruncate
 	featureFunction
 	featureServer
+	featureCreateRoleSelfGrant
 )
 
 var (
@@ -115,6 +116,10 @@ var (
 		featureServer: semver.MustParseRange(">=10.0.0"),
 
 		featureDatabaseOwnerRole: semver.MustParseRange(">=15.0.0"),
+
+		// New privileges rules in version 16
+		// https://www.postgresql.org/docs/16/release-16.html#RELEASE-16-PRIVILEGES
+		featureCreateRoleSelfGrant: semver.MustParseRange(">=16.0.0"),
 	}
 )
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
     postgres:
         image: postgres:${PGVERSION:-latest}

--- a/tests/switch_rds.sh
+++ b/tests/switch_rds.sh
@@ -6,15 +6,24 @@ source "$HERE/switch_superuser.sh"
 
 echo "Switching to an RDS-like environment"
 psql -d postgres  > /dev/null <<EOS
-BEGIN;
-    CREATE role rds LOGIN CREATEDB CREATEROLE PASSWORD 'rds';
-    -- On RDS, postgres user is member of these roles
-    -- But it's not really needed for the tests and pg_monitor is
-    -- not available on Posgres 8.x
-    -- GRANT pg_monitor,pg_signal_backend TO rds;
-    ALTER DATABASE postgres OWNER TO rds;
-    ALTER SCHEMA public OWNER TO rds;
-COMMIT;
+DO
+\$BODY\$
+    DECLARE
+        server_version INT = 0;
+    BEGIN
+        CREATE ROLE rds LOGIN CREATEDB CREATEROLE PASSWORD 'rds';
+        -- On RDS, postgres user is member of these roles
+        -- But it's not really needed for the tests and pg_monitor is
+        -- not available on Posgres 8.x
+        -- GRANT pg_monitor,pg_signal_backend TO rds;
+        ALTER DATABASE postgres OWNER TO rds;
+        ALTER SCHEMA public OWNER TO rds;
+        SELECT setting FROM pg_settings WHERE name = 'server_version_num' INTO server_version;
+        IF server_version >= 160000 THEN
+            ALTER ROLE rds SET createrole_self_grant TO 'set, inherit';
+        END IF;
+    END;
+\$BODY\$;
 EOS
 
 psql -d template1 > /dev/null <<EOS

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -71,6 +71,16 @@ resource "postgresql_database" "my_db2" {
 }
 ```
 
+In postgresql 16 was presented new role security schema and by default is not created non admin grant to newly created roles.
+[Read more](https://www.postgresql.org/docs/16/runtime-config-client.html#GUC-CREATEROLE-SELF-GRANT).
+It can be fixed multiple way. 
+* Set user parameters on non superuser (recommended way) user by
+```postgresql
+ALTER ROLE current_user SET createrole_self_grant TO 'set, inherit';
+```
+* Set postgresql server configuration during server start (not available in most cloud providers yet) 
+* Using superuser for connect to database (not recommend)
+
 ## Injecting Credentials
 There are several methods of providing credentials to the provider without hardcoding them.
 
@@ -185,6 +195,8 @@ The following arguments are supported:
 * `aws_rds_iam_region` - (Optional) The AWS region to use while using AWS RDS IAM Auth.
 * `azure_identity_auth` - (Optional) If set to `true`, call the Azure OAuth token endpoint for temporary token
 * `azure_tenant_id` - (Optional) (Required if `azure_identity_auth` is `true`) Azure tenant ID [read more](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config.html)
+* `user_parameters` - (Optional) Set user parameters for `username` user
+  * `createrole_self_grant` - (Optional) The value must be `set`, `inherit`, or a comma-separated list of these
 
 ## GoCloud
 

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -118,6 +118,9 @@ resource "postgresql_role" "my_replication_role" {
 
 * `assume_role` - (Optional) Defines the role to switch to at login via [`SET ROLE`](https://www.postgresql.org/docs/current/sql-set-role.html).
 
+* `parameters` - (Optional) Defines role parameters as map of strings.
+  * `createrole_self_grant` - (Optional) If a user who has CREATEROLE but not SUPERUSER creates a role, and if this is set to a non-empty value, the newly-created role will be granted to the creating user with the options specified. Since Postgresql 16.
+
 ## Import Example
 
 `postgresql_role` supports importing resources.  Supposing the following


### PR DESCRIPTION
Fixes #407 

* Added `parameters` attribute to **postgresql_role** resource.
* Bumped golang version (1.21 is minimal because `slices.Contains()`)
* Enhanced .gitignore
* Added feature enum for Postgresql 16 **create role self grant**
* Added warning to provider configuration if **create role self grant** is not set properly on connection user
* Fixed test for Postgresql 16 compatibility