### PR TITLE
chore(tests): Remove Postrges 11 from tests matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        pgversion: [16, 15, 14, 13, 12, 11]
+        pgversion: [16, 15, 14, 13, 12]
 
     env:
       PGVERSION: ${{ matrix.pgversion }}


### PR DESCRIPTION
The version is not supported anymore by Postgres