### PR TITLE
Fix typos

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,7 @@ signs:
   - artifacts: checksum
     args:
       # if you are using this is a GitHub action or some other automated pipeline, you
-      # need to pass the batch flag to indicate its not interactive.
+      # need to pass the batch flag to indicate it's not interactive.
       - "--batch"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Terraform Provider for PostgreSQL
 =================================
 
-This provider allows to manage with Terraform [Postgresql](https://www.postgresql.org/) objects like databases, extensions, roles, etc..
+This provider allows to manage with Terraform [Postgresql](https://www.postgresql.org/) objects like databases, extensions, roles, etc.
 
 It's published on the [Terraform registry](https://registry.terraform.io/providers/cyrilgdn/postgresql/latest/docs).
 It replaces https://github.com/hashicorp/terraform-provider-postgresql since Hashicorp stopped hosting community providers in favor of the Terraform registry.

--- a/examples/rds/postgresql/README.md
+++ b/examples/rds/postgresql/README.md
@@ -1,6 +1,6 @@
 #RDS instance
 
-This module creates a RDS Postgresql database instance to test the Terraform provider.
+This module creates an RDS Postgresql database instance to test the Terraform provider.
 
 :warning: **This creates a wide publicly accessible database (with a default hardcoded password).**
 :warning: **This is only for tests purpose and should be destroyed as soon as possible.**

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -307,7 +307,7 @@ func (c *Client) Connect() (*DBConnection, error) {
 
 		// We don't want to retain connection
 		// So when we connect on a specific database which might be managed by terraform,
-		// we don't keep opened connection in case of the db has to be dopped in the plan.
+		// we don't keep opened connection in case of the db has to be dropped in the plan.
 		db.SetMaxIdleConns(0)
 		db.SetMaxOpenConns(c.config.MaxConns)
 

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -179,7 +179,7 @@ func withRolesGranted(txn *sql.Tx, roles []string, fn func() error) error {
 		// in order to manipulate its objects/privileges.
 		// But PostgreSQL prevents `foo` to be a member of the role `postgres`,
 		// and for `postgres` to be a member of the role `foo`, at the same time.
-		// In this case we will temporary revoke this privilege.
+		// In this case we will temporarily revoke this privilege.
 		// So, the following queries will happen (in the same transaction):
 		//  - REVOKE postgres FROM foo
 		//  - GRANT foo TO postgres
@@ -294,7 +294,7 @@ func resourcePrivilegesEqual(granted *schema.Set, d *schema.ResourceData) bool {
 	}
 
 	// implicit check: e.g. for object_type schema -> ALL == ["CREATE", "USAGE"]
-	log.Printf("The wanted privilege is 'ALL'. therefore, we will check if the current privileges are ALL implicitely")
+	log.Printf("The wanted privilege is 'ALL'. therefore, we will check if the current privileges are ALL implicitly")
 	implicits := []interface{}{}
 	for _, p := range allowedPrivileges[objectType] {
 		if p != "ALL" {

--- a/postgresql/helpers_test.go
+++ b/postgresql/helpers_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestFindStringSubmatchMap(t *testing.T) {
 
-	resultMap := findStringSubmatchMap(`(?si).*\$(?P<Body>.*)\$.*`, "aa $somehing_to_extract$ bb")
+	resultMap := findStringSubmatchMap(`(?si).*\$(?P<Body>.*)\$.*`, "aa $something_to_extract$ bb")
 
 	assert.Equal(t,
 		resultMap,
 		map[string]string{
-			"Body": "somehing_to_extract",
+			"Body": "something_to_extract",
 		},
 	)
 }

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -54,7 +54,7 @@ func Provider() *schema.Provider {
 			"database": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The name of the database to connect to in order to conenct to (defaults to `postgres`).",
+				Description: "The name of the database to connect to in order to connect to (defaults to `postgres`).",
 				DefaultFunc: schema.EnvDefaultFunc("PGDATABASE", "postgres"),
 			},
 			"username": {
@@ -120,7 +120,7 @@ func Provider() *schema.Provider {
 				Description: "Service account to impersonate when using GCP IAM authentication.",
 			},
 
-			// Conection username can be different than database username with user name mapas (e.g.: in Azure)
+			// Connection username can be different than database username with user name maps (e.g.: in Azure)
 			// See https://www.postgresql.org/docs/current/auth-username-maps.html
 			"database_username": {
 				Type:        schema.TypeString,

--- a/postgresql/resource_postgresql_database_test.go
+++ b/postgresql/resource_postgresql_database_test.go
@@ -135,7 +135,7 @@ func TestAccPostgresqlDatabase_Update(t *testing.T) {
 	// Version dependent features values will be set in PreCheck
 	// because we need to access database to check Postgres version.
 
-	// Allow connection depends of Postgres version (needs pg >= 9.5)
+	// Allow connection depends on Postgres version (needs pg >= 9.5)
 	var allowConnections bool
 
 	resource.Test(t, resource.TestCase{

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -144,7 +144,7 @@ func resourcePostgreSQLDefaultPrivilegesCreate(db *DBConnection, d *schema.Resou
 	if err := withRolesGranted(txn, []string{owner}, func() error {
 
 		// Revoke all privileges before granting otherwise reducing privileges will not work.
-		// We just have to revoke them in the same transaction so role will not lost his privileges
+		// We just have to revoke them in the same transaction so role will not lose its privileges
 		// between revoke and grant.
 		if err = revokeRoleDefaultPrivileges(txn, d); err != nil {
 			return err

--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -195,8 +195,8 @@ resource "postgresql_default_privileges" "test_ro" {
 	})
 }
 
-// Test the case where we define default priviliges without specifying a schema. These
-// priviliges should apply to newly created resources for the named role in all schema.
+// Test the case where we define default privileges without specifying a schema. These
+// privileges should apply to newly created resources for the named role in all schema.
 func TestAccPostgresqlDefaultPrivileges_NoSchema(t *testing.T) {
 	skipIfNotAcc(t)
 

--- a/postgresql/resource_postgresql_extension_test.go
+++ b/postgresql/resource_postgresql_extension_test.go
@@ -14,7 +14,7 @@ func TestAccPostgresqlExtension_Basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testCheckCompatibleVersion(t, featureExtension)
-			// TODO: Need to check how RDS manage to allow `rds_supuser` to create extension
+			// TODO: Need to check how RDS manage to allow `rds_superuser` to create extension
 			// even it's not a real superuser
 			testSuperuserPreCheck(t)
 		},

--- a/postgresql/resource_postgresql_function.go
+++ b/postgresql/resource_postgresql_function.go
@@ -108,7 +108,7 @@ func resourcePostgreSQLFunction() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Default:     "plpgsql",
-				Description: "Language of theof the function. One of: internal, sql, c, plpgsql",
+				Description: "Language of the function. One of: internal, sql, c, plpgsql",
 
 				DiffSuppressFunc: defaultDiffSuppressFunc,
 			},

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -192,7 +192,7 @@ func resourcePostgreSQLGrantCreateOrUpdate(db *DBConnection, d *schema.ResourceD
 	}
 	if err := withRolesGranted(txn, owners, func() error {
 		// Revoke all privileges before granting otherwise reducing privileges will not work.
-		// We just have to revoke them in the same transaction so the role will not lost its
+		// We just have to revoke them in the same transaction so the role will not lose its
 		// privileges between the revoke and grant statements.
 		if err := revokeRolePrivileges(txn, d, usePrevious); err != nil {
 			return err

--- a/postgresql/resource_postgresql_publication_test.go
+++ b/postgresql/resource_postgresql_publication_test.go
@@ -706,7 +706,7 @@ resource "postgresql_publication" "test" {
 					resource.TestCheckResourceAttr(
 						"postgresql_publication.test", pubDatabaseAttr, dbName),
 					resource.TestCheckResourceAttr(
-						"postgresql_publication.test", pubPublisViaPartitionRoothAttr, "false"),
+						"postgresql_publication.test", pubPublishViaPartitionRootAttr, "false"),
 				),
 			},
 			{
@@ -724,7 +724,7 @@ resource "postgresql_publication" "test" {
 					resource.TestCheckResourceAttr(
 						"postgresql_publication.test", fmt.Sprintf("%s.1", pubPublishAttr), "delete"),
 					resource.TestCheckResourceAttr(
-						"postgresql_publication.test", pubPublisViaPartitionRoothAttr, "true"),
+						"postgresql_publication.test", pubPublishViaPartitionRootAttr, "true"),
 				),
 			},
 		},
@@ -809,7 +809,7 @@ resource "postgresql_publication" "test" {
 			},
 			{
 				Config:      testAccPostgresqlPublicationWrongKeys,
-				ExpectError: regexp.MustCompile("could not update publication tables: Error getting publication paramters: invalid value of `publish_param`: wrong_param. Should be at least one of 'insert, update, delete, truncate'"),
+				ExpectError: regexp.MustCompile("could not update publication tables: Error getting publication parameters: invalid value of `publish_param`: wrong_param. Should be at least one of 'insert, update, delete, truncate'"),
 			},
 			{
 				Config:      testAccPostgresqlPublicationDuplicateKeys,

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -499,7 +499,7 @@ func readSearchPath(roleConfig pq.ByteaArray) []string {
 	return nil
 }
 
-// readIdleInTransactionSessionTimeout searches for a idle_in_transaction_session_timeout entry in the rolconfig array.
+// readIdleInTransactionSessionTimeout searches for an idle_in_transaction_session_timeout entry in the rolconfig array.
 // In case no such value is present, it returns nil.
 func readIdleInTransactionSessionTimeout(roleConfig pq.ByteaArray) (int, error) {
 	for _, v := range roleConfig {

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -509,7 +509,7 @@ func setSchemaPolicy(txn *sql.Tx, d *schema.ResourceData) error {
 
 // schemaChangedPolicies walks old and new to create a set of queries that can
 // be executed to enact each type of state change (roles that have been dropped
-// from the policy, added to a policy, have updated privilges, or are
+// from the policy, added to a policy, have updated privileges, or are
 // unchanged).
 func schemaChangedPolicies(old, new []interface{}) (dropped, added, update, unchanged map[string]interface{}) {
 	type RoleKey string

--- a/postgresql/resource_postgresql_schema_test.go
+++ b/postgresql/resource_postgresql_schema_test.go
@@ -56,7 +56,7 @@ func TestAccPostgresqlSchema_AddPolicy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			// TODO: Need to check if remooving policy is buggy
+			// TODO: Need to check if removing policy is buggy
 			// because non-superuser fails to drop a role
 			testSuperuserPreCheck(t)
 		},

--- a/postgresql/resource_postgresql_subscription.go
+++ b/postgresql/resource_postgresql_subscription.go
@@ -82,7 +82,7 @@ func resourcePostgreSQLSubscriptionCreate(db *DBConnection, d *schema.ResourceDa
 
 	optionalParams := getOptionalParameters(d)
 
-	// Creating of a subscription can not be done in an transaction
+	// Creating of a subscription can not be done in a transaction
 	client := db.client.config.NewClient(databaseName)
 	conn, err := client.Connect()
 	if err != nil {

--- a/postgresql/utils_test.go
+++ b/postgresql/utils_test.go
@@ -339,7 +339,7 @@ func createTestSequences(t *testing.T, dbSuffix string, sequences []string, owne
 }
 
 // testHasGrantForQuery executes a query and checks that it fails if
-// we were not allowed or succeses if we're allowed.
+// we were not allowed or success if we're allowed.
 func testHasGrantForQuery(db *sql.DB, query string, allowed bool) error {
 	_, err := db.Exec(query)
 	if err != nil {

--- a/tests/switch_rds.sh
+++ b/tests/switch_rds.sh
@@ -10,7 +10,7 @@ BEGIN;
     CREATE role rds LOGIN CREATEDB CREATEROLE PASSWORD 'rds';
     -- On RDS, postgres user is member of these roles
     -- But it's not really needed for the tests and pg_monitor is
-    -- not available on Posgres 8.x
+    -- not available on Postgres 8.x
     -- GRANT pg_monitor,pg_signal_backend TO rds;
     ALTER DATABASE postgres OWNER TO rds;
     ALTER SCHEMA public OWNER TO rds;

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -156,7 +156,7 @@ The following arguments are supported:
   In this case, some features might be disabled (e.g.: Refreshing state password from database).
 * `sslmode` - (Optional) Set the priority for an SSL connection to the server.
   Valid values for `sslmode` are (note: `prefer` is not supported by Go's
-  [`lib/pq`][libpq])):
+  [`lib/pq`][libpq]):
     * disable - No SSL
     * require - Always SSL (the default, also skip verification)
     * verify-ca - Always SSL (verify that the certificate presented by the server was signed by a trusted CA)

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -109,7 +109,7 @@ resource "postgresql_role" "my_replication_role" {
   databases and the ROLE is dropped, a
   [`REASSIGN OWNED`](https://www.postgresql.org/docs/current/static/sql-reassign-owned.html) in
   must be executed on each of the respective databases before the `DROP ROLE`
-  can be executed to dropped the ROLE from the catalog.  This is the first and
+  can be executed to drop the ROLE from the catalog.  This is the first and
   second steps taken when removing a ROLE from a database (the second step being
   an implicit
   [`DROP OWNED`](https://www.postgresql.org/docs/current/static/sql-drop-owned.html)).

--- a/website/docs/r/postgresql_subscription.markdown
+++ b/website/docs/r/postgresql_subscription.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "postgresql"
-page_title: "PostgreSQL: postgresql_susbcription"
+page_title: "PostgreSQL: postgresql_subscription"
 sidebar_current: "docs-postgresql-resource-postgresql_subscription"
 description: |-
 Creates and manages a subscription in a PostgreSQL server database.


### PR DESCRIPTION
Just thought I'd contribute some typo fixes I've stumbled upon.

FYI, the top typos are:
* publis
* rooth
* parmeter
* paramters
* somehing
* priviliges
* susbcription
* privilges
* remooving
* succeses
* conenct
* dopped
* implicitely
* mapas