### PR TITLE
Add docs about support for `GOOGLE_CREDENTIALS` for GCP auth

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -215,10 +215,12 @@ To enable GoCloud for GCP SQL, set `scheme` to `gcppostgres` and `host` to the c
 For GCP, GoCloud also requires the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to be set to the service account credentials file.
 These credentials can be created here: https://console.cloud.google.com/iam-admin/serviceaccounts
 
+Alternatively, you can set the `GOOGLE_CREDENTIALS` environment variable to the JSON content of the service account credentials.
+
 In addition, the provider supports service account impersonation with the `gcp_iam_impersonate_service_account` option. You must ensure:
 
 - The IAM database user has sufficient permissions to connect to the database, e.g., `roles/cloudsql.instanceUser`
-- The principal (IAM user or IAM service account) behind the `GOOGLE_APPLICATION_CREDENTIALS` has sufficient permissions to impersonate the provided service account. Learn more from [roles for service account authentication](https://cloud.google.com/iam/docs/service-account-permissions).
+- The principal (IAM user or IAM service account) behind the `GOOGLE_APPLICATION_CREDENTIALS`/`GOOGLE_CREDENTIALS` has sufficient permissions to impersonate the provided service account. Learn more from [roles for service account authentication](https://cloud.google.com/iam/docs/service-account-permissions).
 
 ```hcl
 provider "postgresql" {


### PR DESCRIPTION
as the original PR https://github.com/cyrilgdn/terraform-provider-postgresql/pull/249 was missing them