### PR TITLE
support specials on user mapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/sean-/postgresql-acl v0.0.0-20161225120419-d10489e5d217
 	github.com/stretchr/testify v1.9.0
 	gocloud.dev v0.34.0
+	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/net v0.26.0
 	golang.org/x/oauth2 v0.10.0
 	google.golang.org/api v0.134.0

--- a/go.sum
+++ b/go.sum
@@ -1386,6 +1386,7 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/postgresql/resource_postgresql_user_mapping_test.go
+++ b/postgresql/resource_postgresql_user_mapping_test.go
@@ -80,6 +80,65 @@ func TestAccPostgresqlUserMapping_Update(t *testing.T) {
 	})
 }
 
+func TestAccPostgresqlUserMapping_Specials(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureServer)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlUserMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPostgresqlUserMappingSpecialPublicLower,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlUserMappingExists("postgresql_user_mapping.remote"),
+					resource.TestCheckResourceAttr(
+						"postgresql_user_mapping.remote", "user_name", "public"),
+					testCheckUserMappingExists("public", "myserver_postgres"),
+				),
+			},
+			{
+				Config: testAccPostgresqlUserMappingSpecialCurrentRole,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlServerExists("postgresql_user_mapping.remote"),
+					resource.TestCheckResourceAttr(
+						"postgresql_user_mapping.remote", "user_name", "CURRENT_ROLE"),
+					testCheckUserMappingExists("postgres", "myserver_postgres"),
+				),
+			},
+			{
+				Config: testAccPostgresqlUserMappingSpecialCurrentUser,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlServerExists("postgresql_user_mapping.remote"),
+					resource.TestCheckResourceAttr(
+						"postgresql_user_mapping.remote", "user_name", "CURRENT_USER"),
+					testCheckUserMappingExists("postgres", "myserver_postgres"),
+				),
+			},
+			{
+				Config: testAccPostgresqlUserMappingSpecialPublic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlServerExists("postgresql_user_mapping.remote"),
+					resource.TestCheckResourceAttr(
+						"postgresql_user_mapping.remote", "user_name", "PUBLIC"),
+					testCheckUserMappingExists("public", "myserver_postgres"),
+				),
+			},
+			{
+				Config: testAccPostgresqlUserMappingSpecialUser,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlServerExists("postgresql_user_mapping.remote"),
+					resource.TestCheckResourceAttr(
+						"postgresql_user_mapping.remote", "user_name", "USER"),
+					testCheckUserMappingExists("postgres", "myserver_postgres"),
+				),
+			},
+		},
+	})
+}
+
 func checkUserMappingExists(txn *sql.Tx, username string, serverName string) (bool, error) {
 	var _rez bool
 	err := txn.QueryRow("SELECT TRUE FROM pg_user_mappings WHERE usename = $1 AND srvname = $2", username, serverName).Scan(&_rez)
@@ -108,14 +167,16 @@ func testAccCheckPostgresqlUserMappingDestroy(s *terraform.State) error {
 		defer deferredRollback(txn)
 
 		splitted := strings.Split(rs.Primary.ID, ".")
-		exists, err := checkUserMappingExists(txn, splitted[0], splitted[1])
+		username := splitted[0]
+		serverName := splitted[1]
+		exists, err := checkUserMappingExists(txn, username, serverName)
 
 		if err != nil {
 			return fmt.Errorf("Error checking user mapping %s", err)
 		}
 
 		if exists {
-			return fmt.Errorf("User mapping still exists after destroy")
+			return fmt.Errorf("User mapping (%s) for server (%s) still exists after destroy", username, serverName)
 		}
 	}
 
@@ -157,7 +218,30 @@ func testAccCheckPostgresqlUserMappingExists(n string) resource.TestCheckFunc {
 		}
 
 		if !exists {
-			return fmt.Errorf("User mapping not found")
+			return fmt.Errorf("User mapping (%s) for server (%s) not found", username, serverName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckUserMappingExists(username string, serverName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*Client)
+		txn, err := startTransaction(client, "")
+		if err != nil {
+			return err
+		}
+		defer deferredRollback(txn)
+
+		exists, err := checkUserMappingExists(txn, username, serverName)
+
+		if err != nil {
+			return fmt.Errorf("Error checking user mapping %s", err)
+		}
+
+		if !exists {
+			return fmt.Errorf("User mapping (%s) for server (%s) not found", username, serverName)
 		}
 
 		return nil
@@ -166,102 +250,233 @@ func testAccCheckPostgresqlUserMappingExists(n string) resource.TestCheckFunc {
 
 var testAccPostgresqlUserMappingConfig = `
 resource "postgresql_extension" "ext_postgres_fdw" {
-  name = "postgres_fdw"
+	name = "postgres_fdw"
 }
 
 resource "postgresql_server" "myserver_postgres" {
-  server_name = "myserver_postgres"
-  fdw_name    = "postgres_fdw"
-  options = {
-    host   = "foo"
-    dbname = "foodb"
-    port   = "5432"
-  }
+	server_name = "myserver_postgres"
+	fdw_name    = "postgres_fdw"
+	options = {
+		host   = "foo"
+		dbname = "foodb"
+		port   = "5432"
+	}
 
-  depends_on = [postgresql_extension.ext_postgres_fdw]
+	depends_on = [postgresql_extension.ext_postgres_fdw]
 }
 
 resource "postgresql_role" "remote" {
-  name = "remote"
+	name = "remote"
 }
 
 resource "postgresql_user_mapping" "remote" {
-  server_name = postgresql_server.myserver_postgres.server_name
-  user_name   = postgresql_role.remote.name
-  options = {
-    user = "admin"
-    password = "pass"
-  }
+	server_name = postgresql_server.myserver_postgres.server_name
+	user_name   = postgresql_role.remote.name
+	options = {
+		user     = "admin"
+		password = "pass"
+	}
 }
 
 resource "postgresql_role" "special" {
-  name = "special"
+	name = "special"
 }
 
 resource "postgresql_user_mapping" "special_chars" {
-  server_name = postgresql_server.myserver_postgres.server_name
-  user_name   = postgresql_role.special.name
-  options = {
-	user = "admin"
-	password = "pass=$*'"
-  }
+	server_name = postgresql_server.myserver_postgres.server_name
+	user_name   = postgresql_role.special.name
+	options = {
+		user     = "admin"
+		password = "pass=$*'"
+	}
 }
 `
 
 var testAccPostgresqlUserMappingChanges2 = `
 resource "postgresql_extension" "ext_postgres_fdw" {
 	name = "postgres_fdw"
-  }
-  
-  resource "postgresql_server" "myserver_postgres" {
+}
+
+resource "postgresql_server" "myserver_postgres" {
 	server_name = "myserver_postgres"
 	fdw_name    = "postgres_fdw"
 	options = {
-	  host   = "foo"
-	  dbname = "foodb"
-	  port   = "5432"
+		host   = "foo"
+		dbname = "foodb"
+		port   = "5432"
 	}
-  
+
 	depends_on = [postgresql_extension.ext_postgres_fdw]
-  }
-  
-  resource "postgresql_role" "remote" {
+}
+
+resource "postgresql_role" "remote" {
 	name = "remote"
-  }
-  
-  resource "postgresql_user_mapping" "remote" {
+}
+
+resource "postgresql_user_mapping" "remote" {
 	server_name = postgresql_server.myserver_postgres.server_name
 	user_name   = postgresql_role.remote.name
 	options = {
-	  user = "admin"
-	  password = "passUpdated"
+		user     = "admin"
+		password = "passUpdated"
 	}
-  }
+}
 `
 
 var testAccPostgresqlUserMappingChanges3 = `
 resource "postgresql_extension" "ext_postgres_fdw" {
 	name = "postgres_fdw"
-  }
-  
-  resource "postgresql_server" "myserver_postgres" {
+}
+
+resource "postgresql_server" "myserver_postgres" {
 	server_name = "myserver_postgres"
 	fdw_name    = "postgres_fdw"
 	options = {
-	  host   = "foo"
-	  dbname = "foodb"
-	  port   = "5432"
+		host   = "foo"
+		dbname = "foodb"
+		port   = "5432"
 	}
-  
+
 	depends_on = [postgresql_extension.ext_postgres_fdw]
-  }
-  
-  resource "postgresql_role" "remote" {
-	name = "remote"
-  }
-  
-  resource "postgresql_user_mapping" "remote" {
+}
+
+resource "postgresql_role" "remote" {
+name = "remote"
+}
+
+resource "postgresql_user_mapping" "remote" {
 	server_name = postgresql_server.myserver_postgres.server_name
 	user_name   = postgresql_role.remote.name
-  }
+}
+`
+
+var testAccPostgresqlUserMappingSpecialCurrentRole = `
+resource "postgresql_extension" "ext_postgres_fdw" {
+	name = "postgres_fdw"
+}
+
+resource "postgresql_server" "myserver_postgres" {
+	server_name = "myserver_postgres"
+	fdw_name    = "postgres_fdw"
+	options = {
+		host   = "foo"
+		dbname = "foodb"
+		port   = "5432"
+	}
+
+	depends_on = [postgresql_extension.ext_postgres_fdw]
+}
+
+resource "postgresql_user_mapping" "remote" {
+	server_name = postgresql_server.myserver_postgres.server_name
+	user_name   = "CURRENT_ROLE"
+}
+`
+
+var testAccPostgresqlUserMappingSpecialCurrentUser = `
+resource "postgresql_extension" "ext_postgres_fdw" {
+	name = "postgres_fdw"
+}
+
+resource "postgresql_server" "myserver_postgres" {
+	server_name = "myserver_postgres"
+	fdw_name    = "postgres_fdw"
+	options = {
+		host   = "foo"
+		dbname = "foodb"
+		port   = "5432"
+	}
+
+	depends_on = [postgresql_extension.ext_postgres_fdw]
+}
+
+resource "postgresql_user_mapping" "remote" {
+	server_name = postgresql_server.myserver_postgres.server_name
+	user_name   = "CURRENT_USER"
+	options = {
+		user     = "admin"
+		password = "pass"
+	}
+}
+`
+
+var testAccPostgresqlUserMappingSpecialPublicLower = `
+resource "postgresql_extension" "ext_postgres_fdw" {
+	name = "postgres_fdw"
+}
+
+resource "postgresql_server" "myserver_postgres" {
+	server_name = "myserver_postgres"
+	fdw_name    = "postgres_fdw"
+	options = {
+		host   = "foo"
+		dbname = "foodb"
+		port   = "5432"
+	}
+
+	depends_on = [postgresql_extension.ext_postgres_fdw]
+}
+
+resource "postgresql_user_mapping" "remote" {
+	server_name = postgresql_server.myserver_postgres.server_name
+	user_name   = "public"
+	options = {
+		user     = "admin"
+		password = "pass"
+	}
+}
+`
+
+var testAccPostgresqlUserMappingSpecialPublic = `
+resource "postgresql_extension" "ext_postgres_fdw" {
+	name = "postgres_fdw"
+}
+
+resource "postgresql_server" "myserver_postgres" {
+	server_name = "myserver_postgres"
+	fdw_name    = "postgres_fdw"
+	options = {
+		host   = "foo"
+		dbname = "foodb"
+		port   = "5432"
+	}
+
+	depends_on = [postgresql_extension.ext_postgres_fdw]
+}
+
+resource "postgresql_user_mapping" "remote" {
+	server_name = postgresql_server.myserver_postgres.server_name
+	user_name   = "PUBLIC"
+	options = {
+		user     = "admin"
+		password = "pass"
+	}
+}
+`
+
+var testAccPostgresqlUserMappingSpecialUser = `
+resource "postgresql_extension" "ext_postgres_fdw" {
+	name = "postgres_fdw"
+}
+
+resource "postgresql_server" "myserver_postgres" {
+	server_name = "myserver_postgres"
+	fdw_name    = "postgres_fdw"
+	options = {
+		host   = "foo"
+		dbname = "foodb"
+		port   = "5432"
+	}
+
+	depends_on = [postgresql_extension.ext_postgres_fdw]
+}
+
+resource "postgresql_user_mapping" "remote" {
+	server_name = postgresql_server.myserver_postgres.server_name
+	user_name   = "USER"
+	options = {
+		user     = "admin"
+		password = "pass'"
+	}
+}
 `


### PR DESCRIPTION
Hi!

This PR add support for special username cases on user mapping.

* for `CURRENT_ROLE`, `CURRENT_USER`, `USER`: use current user (so provider one)
* for `PUBLIC`: use `public` role
