### PR TITLE
feat: add `gcp_credentials_path` argument (#147)

### DIFF
--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -120,6 +120,13 @@ func Provider() *schema.Provider {
 				Description: "Service account to impersonate when using GCP IAM authentication.",
 			},
 
+			"gcp_credentials_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "Path to GCP credentials file",
+			},
+
 			// Connection username can be different than database username with user name maps (e.g.: in Azure)
 			// See https://www.postgresql.org/docs/current/auth-username-maps.html
 			"database_username": {
@@ -286,7 +293,13 @@ func getRDSAuthToken(region string, profile string, role string, username string
 	return token, err
 }
 
-func createGoogleCredsFileIfNeeded() error {
+func createGoogleCredsFileIfNeeded(gcpCredentialsPath string) error {
+	const GoogleCredentialsEnvVar = "GOOGLE_APPLICATION_CREDENTIALS"
+
+	if gcpCredentialsPath != "" {
+		return os.Setenv(GoogleCredentialsEnvVar, gcpCredentialsPath)
+	}
+
 	if _, err := google.FindDefaultCredentials(context.Background()); err == nil {
 		return nil
 	}
@@ -307,7 +320,7 @@ func createGoogleCredsFileIfNeeded() error {
 		return fmt.Errorf("could not write in temporary file: %w", err)
 	}
 
-	return os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", tmpFile.Name())
+	return os.Setenv(GoogleCredentialsEnvVar, tmpFile.Name())
 }
 
 func acquireAzureOauthToken(tenantId string) (string, error) {
@@ -395,7 +408,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	if config.Scheme == "gcppostgres" {
-		if err := createGoogleCredsFileIfNeeded(); err != nil {
+		if err := createGoogleCredsFileIfNeeded(d.Get("gcp_credentials_path").(string)); err != nil {
 			return nil, err
 		}
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -186,6 +186,7 @@ The following arguments are supported:
 * `aws_rds_iam_provider_role_arn` - (Optional) AWS IAM role to assume while using AWS RDS IAM Auth.
 * `azure_identity_auth` - (Optional) If set to `true`, call the Azure OAuth token endpoint for temporary token
 * `azure_tenant_id` - (Optional) (Required if `azure_identity_auth` is `true`) Azure tenant ID [read more](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config.html)
+* `gcp_credentials_path` - (Optional) The path to the GCP credentials file. This is only used if `scheme` is set to `gcppostgres`.
 
 ## GoCloud
 
@@ -212,7 +213,7 @@ provider "postgresql" {
 
 To enable GoCloud for GCP SQL, set `scheme` to `gcppostgres` and `host` to the connection name of the instance in following format: `project/region/instance` (or `project:region:instance`).
 
-For GCP, GoCloud also requires the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to be set to the service account credentials file.
+For GCP, GoCloud also requires the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to be set to the service account credentials file. In alternative, you could set `gcp_credentials_path` to the credentials file.
 These credentials can be created here: https://console.cloud.google.com/iam-admin/serviceaccounts
 
 In addition, the provider supports service account impersonation with the `gcp_iam_impersonate_service_account` option. You must ensure:


### PR DESCRIPTION
Fixes #147 

The argument can be used to configure the provider with google credentials. This is an alternative to setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable