### PR TITLE
Add provider options for DB Connection Pools

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 
 	"github.com/blang/semver"
@@ -179,6 +180,9 @@ type Config struct {
 	Timeout                         int
 	ConnectTimeoutSec               int
 	MaxConns                        int
+	MaxIdleConns                    int
+	ConnMaxIdleTime                 time.Duration
+	ConnMaxLifetime                 time.Duration
 	ExpectedVersion                 semver.Version
 	SSLClientCert                   *ClientCertificateConfig
 	SSLRootCertPath                 string
@@ -308,8 +312,10 @@ func (c *Client) Connect() (*DBConnection, error) {
 		// We don't want to retain connection
 		// So when we connect on a specific database which might be managed by terraform,
 		// we don't keep opened connection in case of the db has to be dropped in the plan.
-		db.SetMaxIdleConns(0)
+		db.SetMaxIdleConns(c.config.MaxIdleConns)
 		db.SetMaxOpenConns(c.config.MaxConns)
+		db.SetConnMaxIdleTime(c.config.ConnMaxIdleTime)
+		db.SetConnMaxIdleTime(c.config.ConnMaxLifetime)
 
 		defaultVersion, _ := semver.Parse(defaultExpectedPostgreSQLVersion)
 		version := &c.config.ExpectedVersion


### PR DESCRIPTION
The defaults maintain the current configuration, but this allows users to tune db connections for individual needs.

In particular, even with the latest go libraries, we often encounter "cannot allocate memory" errors when creating yet another DB connection. We have a large number of resources across multiple DBs, so this happens frequently. For our uses, enabling connection pooling is going to save us a lot of headaches, and the edge case disabling the connection pooling is guarding against unlikely to be an issue.