### PR TITLE
Add MAINTAIN table privilege, added in Postgres 17

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -251,7 +251,7 @@ func sliceContainsStr(haystack []string, needle string) bool {
 // see: https://www.postgresql.org/docs/current/sql-grant.html
 var allowedPrivileges = map[string][]string{
 	"database":             {"ALL", "CREATE", "CONNECT", "TEMPORARY"},
-	"table":                {"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"},
+	"table":                {"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"},
 	"sequence":             {"ALL", "USAGE", "SELECT", "UPDATE"},
 	"schema":               {"ALL", "CREATE", "USAGE"},
 	"function":             {"ALL", "EXECUTE"},


### PR DESCRIPTION
The `MAINTAIN` privilege is added in Postgres 17 (see [here](https://www.postgresql.org/docs/17/sql-grant.html)). Without it, even the owner of the table cannot perform tasks like `VACUUM`, `ANALYZE`, or `REINDEX`.

Upon adding this privilege, we got this error:

```
Error: MAINTAIN is not an allowed privilege for object type table
```

Upon a closer investigation, the list of table privileges in `allowedPrivileges` needs to be augmented.

The following query on Postgres 17 shows all valid privilesges for different types of Postgres objects:

```sql
with t(col) as (
  select string_to_table('cdfFlLnprsStT', null)
)
select col as object_type, array_agg(privilege_type) as privileges
from t
join lateral aclexplode(acldefault(col::"char", 0)) as a on true
group by 1
order by 1;
```

Result:
<img width="1096" height="451" alt="image" src="https://github.com/user-attachments/assets/e0d9059c-b1d8-4073-9b4b-f59b6fd7c174" />

