### PR TITLE
Fix identifier quoting in postgresql_publication resource

### DIFF
--- a/postgresql/resource_postgresql_publication.go
+++ b/postgresql/resource_postgresql_publication.go
@@ -158,7 +158,7 @@ func setPubOwner(txn *sql.Tx, d *schema.ResourceData) error {
 	n := nraw.(string)
 	pubName := d.Get(pubNameAttr).(string)
 
-	sql := fmt.Sprintf("ALTER PUBLICATION %s OWNER TO %s", pubName, n)
+	sql := fmt.Sprintf("ALTER PUBLICATION %s OWNER TO %s", pq.QuoteIdentifier(pubName), pq.QuoteIdentifier(n))
 	if _, err := txn.Exec(sql); err != nil {
 		return fmt.Errorf("error updating publication owner: %w", err)
 	}
@@ -183,12 +183,12 @@ func setPubTables(txn *sql.Tx, d *schema.ResourceData) error {
 	added := arrayDifference(newList, oldList)
 
 	for _, p := range added {
-		query := fmt.Sprintf("ALTER PUBLICATION %s ADD TABLE %s", pubName, quoteTableName(p.(string)))
+		query := fmt.Sprintf("ALTER PUBLICATION %s ADD TABLE %s", pq.QuoteIdentifier(pubName), quoteTableName(p.(string)))
 		queries = append(queries, query)
 	}
 
 	for _, p := range dropped {
-		query := fmt.Sprintf("ALTER PUBLICATION %s DROP TABLE %s", pubName, quoteTableName(p.(string)))
+		query := fmt.Sprintf("ALTER PUBLICATION %s DROP TABLE %s", pq.QuoteIdentifier(pubName), quoteTableName(p.(string)))
 		queries = append(queries, query)
 	}
 
@@ -208,7 +208,7 @@ func setPubParams(txn *sql.Tx, d *schema.ResourceData, pubViaRootEnabled bool) e
 		return fmt.Errorf("error getting publication parameters: %w", err)
 	}
 	if publicationParametersString != "" {
-		sql := fmt.Sprintf(paramAlterTemplate, pubName, publicationParametersString)
+		sql := fmt.Sprintf(paramAlterTemplate, pq.QuoteIdentifier(pubName), publicationParametersString)
 		if _, err := txn.Exec(sql); err != nil {
 			return fmt.Errorf("error updating publication parameters: %w", err)
 		}
@@ -240,7 +240,7 @@ func resourcePostgreSQLPublicationCreate(db *DBConnection, d *schema.ResourceDat
 	}
 	defer deferredRollback(txn)
 
-	sql := fmt.Sprintf("CREATE PUBLICATION %s %s %s", name, tables, publicationParameters)
+	sql := fmt.Sprintf("CREATE PUBLICATION %s %s %s", pq.QuoteIdentifier(name), tables, publicationParameters)
 
 	if _, err := txn.Exec(sql); err != nil {
 		return fmt.Errorf("error creating Publication: %w", err)

--- a/postgresql/resource_postgresql_publication_test.go
+++ b/postgresql/resource_postgresql_publication_test.go
@@ -366,7 +366,7 @@ func TestAccPostgresqlPublication_UpdateOwner(t *testing.T) {
 
 	testAccPostgresqlPublicationUpdateOwnerConfig := fmt.Sprintf(`
 	resource "postgresql_role" "test_owner_2" {
-		name = "%s_2"
+		name = "%s-2"
 		login = true
 	}
 	resource "postgresql_publication" "test" {
@@ -403,11 +403,11 @@ func TestAccPostgresqlPublication_UpdateOwner(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPostgresqlPublicationExists("postgresql_publication.test"),
 					resource.TestCheckResourceAttr(
-						"postgresql_role.test_owner_2", "name", fmt.Sprintf("%s_2", testOwner)),
+						"postgresql_role.test_owner_2", "name", fmt.Sprintf("%s-2", testOwner)),
 					resource.TestCheckResourceAttr(
 						"postgresql_publication.test", "name", "publication"),
 					resource.TestCheckResourceAttr(
-						"postgresql_publication.test", "owner", fmt.Sprintf("%s_2", testOwner)),
+						"postgresql_publication.test", "owner", fmt.Sprintf("%s-2", testOwner)),
 					resource.TestCheckResourceAttr(
 						"postgresql_publication.test", "database", dbName),
 				),
@@ -426,14 +426,14 @@ func TestAccPostgresqlPublication_UpdateName(t *testing.T) {
 
 	testAccPostgresqlPublicationBaseConfig := fmt.Sprintf(`
 	resource "postgresql_publication" "test" {
-		name     = "%s_publication_1"
+		name     = "%s-publication-1"
 		database = "%s"
 	}
 	`, dbName, dbName)
 
 	testAccPostgresqlPublicationUpdateNameConfig := fmt.Sprintf(`
 	resource "postgresql_publication" "test" {
-		name     = "%s_publication_2"
+		name     = "%s-publication-2"
 		database = "%s"
 	}
 	`, dbName, dbName)
@@ -453,7 +453,7 @@ func TestAccPostgresqlPublication_UpdateName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPostgresqlPublicationExists("postgresql_publication.test"),
 					resource.TestCheckResourceAttr(
-						"postgresql_publication.test", "name", fmt.Sprintf("%s_publication_1", dbName)),
+						"postgresql_publication.test", "name", fmt.Sprintf("%s-publication-1", dbName)),
 					resource.TestCheckResourceAttr(
 						"postgresql_publication.test", "database", dbName),
 				),
@@ -463,7 +463,7 @@ func TestAccPostgresqlPublication_UpdateName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPostgresqlPublicationExists("postgresql_publication.test"),
 					resource.TestCheckResourceAttr(
-						"postgresql_publication.test", "name", fmt.Sprintf("%s_publication_2", dbName)),
+						"postgresql_publication.test", "name", fmt.Sprintf("%s-publication-2", dbName)),
 					resource.TestCheckResourceAttr(
 						"postgresql_publication.test", "database", dbName),
 				),
@@ -473,7 +473,7 @@ func TestAccPostgresqlPublication_UpdateName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPostgresqlPublicationExists("postgresql_publication.test"),
 					resource.TestCheckResourceAttr(
-						"postgresql_publication.test", "name", fmt.Sprintf("%s_publication_1", dbName)),
+						"postgresql_publication.test", "name", fmt.Sprintf("%s-publication-1", dbName)),
 					resource.TestCheckResourceAttr(
 						"postgresql_publication.test", "database", dbName),
 				),


### PR DESCRIPTION
## Description

Fixes #577

This PR adds proper identifier quoting using `pq.QuoteIdentifier()` for publication names and owner names in all SQL statements within the `postgresql_publication` resource.

## Problem

When setting a publication owner or name containing special characters (e.g., hyphens like `tenant-management-user`), the resource failed with a syntax error:

```
Error: could not update publication owner: Error updating publication owner: pq: syntax error at or near "-"
```

This occurred because identifiers were not properly quoted in SQL statements.

## Solution

Added `pq.QuoteIdentifier()` to all publication and owner name references in:
- `CREATE PUBLICATION` statements
- `ALTER PUBLICATION ... OWNER TO` statements
- `ALTER PUBLICATION ... ADD/DROP TABLE` statements
- `ALTER PUBLICATION ... SET` statements (parameter updates)

This aligns the publication resource with the identifier quoting standards already implemented in other resources (database, schema, role, etc.).

## Testing

- ✅ All publication acceptance tests pass, including `TestAccPostgresqlPublication_UpdateOwner` and `TestAccPostgresqlPublication_UpdateName`
- ✅ Tests now validate identifiers with hyphens work correctly
