### PR TITLE
feat: Support for importing postgresql_grant resources

### DIFF
--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -167,6 +167,7 @@ func resourcePostgreSQLGrantImport(ctx context.Context, d *schema.ResourceData, 
 	}
 	d.Set("with_grant_option", withGrantOption)
 
+	d.SetId(generateGrantID(d)) // Import ID is the same as the generated ID for backwards compatibility
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/website/docs/r/postgresql_grant.html.markdown
+++ b/website/docs/r/postgresql_grant.html.markdown
@@ -65,3 +65,30 @@ resource "postgresql_grant" "revoke_public" {
   privileges  = []
 }
 ```
+
+## Import
+
+`postgresql_grant` supports importing resources following the format:
+
+```
+<role>@<database>@<object_type>@[<schema>]@[<objects>]@[<columns>]@<with_grant_option>
+```
+
+Field positions have to be maintained. If the resource you are importing doesn't have a value
+for a field (`schema`, `objects` or `columns`), you should use an empty string for that field.
+
+For example:
+
+```tf
+resource "postgresql_grant" "demo" {
+  database    = "test_db"
+  role        = "demo"
+  schema      = "public"
+  object_type = "schema"
+  privileges  = ["USAGE", "CREATE"]
+}
+```
+
+```bash
+terraform import postgresql_grant.demo demo@test_db@schema@public@@@false
+```


### PR DESCRIPTION
Currently, `postgresql_grant` resources cannot be imported, which forces you to recreate each grant without seeing the current grant status.

This PR adds support for importing `postgresql_grant` resources into the Terraform state.

The import ID format would be defined as:

```
<role>@<database>@<object_type>@[<schema>]@[<objects>]@[<columns>]@<with_grant_option>
```

