### PR TITLE
Add disabled parameter to provider

### DIFF
--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -199,6 +199,12 @@ func Provider() *schema.Provider {
 				Description:  "Specify the expected version of PostgreSQL.",
 				ValidateFunc: validateExpectedVersion,
 			},
+			"disabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Disable the provider from making any changes to PostgreSQL. When set to true, the provider will not connect to the database.",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -331,6 +337,11 @@ func acquireAzureOauthToken(tenantId string) (string, error) {
 }
 
 func providerConfigure(d *schema.ResourceData) (any, error) {
+	// If disabled, return nil to prevent any database connections
+	if d.Get("disabled").(bool) {
+		return nil, nil
+	}
+
 	var sslMode string
 	if sslModeRaw, ok := d.GetOk("sslmode"); ok {
 		sslMode = sslModeRaw.(string)

--- a/postgresql/provider_disabled_test.go
+++ b/postgresql/provider_disabled_test.go
@@ -1,0 +1,50 @@
+package postgresql
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestProviderConfigure_Disabled(t *testing.T) {
+	raw := map[string]interface{}{
+		"disabled": true,
+		"host":     "localhost",
+		"port":     5432,
+		"username": "postgres",
+		"password": "test",
+	}
+
+	p := Provider()
+	d := schema.TestResourceDataRaw(t, p.Schema, raw)
+
+	client, err := providerConfigure(d)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if client != nil {
+		t.Fatal("expected client to be nil when disabled=true")
+	}
+}
+
+func TestProviderConfigure_NotDisabled(t *testing.T) {
+	raw := map[string]interface{}{
+		"disabled": false,
+		"host":     "localhost",
+		"port":     25432,
+		"username": "postgres",
+		"password": "postgres",
+		"database": "postgres",
+	}
+
+	p := Provider()
+	d := schema.TestResourceDataRaw(t, p.Schema, raw)
+
+	client, err := providerConfigure(d)
+	
+	// Client creation will likely fail without a real DB, but that's ok
+	// We just want to verify it doesn't return early like disabled=true does
+	_ = client
+	_ = err
+}


### PR DESCRIPTION
Adds a `disabled` boolean parameter to the provider configuration that prevents database connections when enabled.

This is needed in my case where I create a database conditionally, and in the case the DB is not created, I don't want this provider to run at all.

When `disabled=true`, the provider skips connection setup and all operations.

Example usage:
```hcl
provider "postgresql" {
  disabled = true
}

provider "postgresql" {
  alias = "active"

  scheme    = "awspostgres"
  host      = module.db[0].cluster_endpoint
  port      = module.db[0].port
  database  = module.db[0].database_name
  username  = "postgres"
  password  = module.db[0].postgres_master_password
}
```