### PR TITLE
Add Enabled flag to creating subscription

### DIFF
--- a/postgresql/resource_postgresql_subscription.go
+++ b/postgresql/resource_postgresql_subscription.go
@@ -63,6 +63,13 @@ func resourcePostgreSQLSubscription() *schema.Resource {
 				Description:  "Name of the replication slot to use. The default behavior is to use the name of the subscription for the slot name",
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     true,
+				Description: "Specifies whether the subscription should be actively replicating or whether it should just be set up but not started yet. The default is true.",
+			},
 		},
 	}
 }

--- a/postgresql/resource_postgresql_subscription.go
+++ b/postgresql/resource_postgresql_subscription.go
@@ -319,8 +319,9 @@ func getOptionalParameters(d *schema.ResourceData) string {
 
 	createSlot, okCreate := d.GetOkExists("create_slot") //nolint:staticcheck
 	slotName, okName := d.GetOk("slot_name")
+	enabled, okEnabled := d.GetOk("enabled")
 
-	if !okCreate && !okName {
+	if !okCreate && !okName && !okEnabled {
 		// use default behavior, no WITH statement
 		return ""
 	}
@@ -331,6 +332,9 @@ func getOptionalParameters(d *schema.ResourceData) string {
 	}
 	if okName {
 		params = append(params, fmt.Sprintf("%s = %s", "slot_name", pq.QuoteLiteral(slotName.(string))))
+	}
+	if okEnabled {
+		params = append(params, fmt.Sprintf("%s = %t", "enabled", enabled.(bool)))
 	}
 
 	returnValue = fmt.Sprintf(parameterSQLTemplate, strings.Join(params, ", "))


### PR DESCRIPTION
When trying to set up replication manually, i need the subscription to be initially disabled. This is so that I can set the LSN to a future value once my cloning is complete. I'm working on a project that requires a manual Blue/Green setup and setting up a disabled subscription is necessary.