### PR TITLE
Add configuration parameters support for postgresql_database resource

### DIFF
--- a/examples/database-with-parameters/README.md
+++ b/examples/database-with-parameters/README.md
@@ -1,0 +1,74 @@
+# Database with Configuration Parameters Example
+
+This example demonstrates how to create a PostgreSQL database with custom configuration parameters using the `parameter` block.
+
+## What This Example Does
+
+This example shows how to:
+- Create a database with multiple configuration parameters
+- Set numeric parameters (like `work_mem`, `max_parallel_workers`)
+- Set string parameters with proper quoting
+- Configure database-level settings that override instance defaults
+
+## Configuration Parameters
+
+The example sets the following parameters:
+
+- `work_mem`: Amount of memory to be used by internal sort operations and hash tables before writing to temporary disk files (use `quote = true` for values with units)
+- `max_parallel_workers`: Maximum number of parallel workers that can be active at one time (use `quote = false` for numeric values)
+- `statement_timeout`: Maximum allowed duration of any statement in milliseconds (use `quote = false` for numeric values)
+- `default_statistics_target`: Default statistics target for table columns (use `quote = false` for numeric values)
+- `search_path`: Schema search path for unqualified object names (use `quote = true` for string values)
+
+### Quote Parameter Guidelines
+
+- **`quote = true`** (default): Use for:
+  - Values with units (e.g., `"16MB"`, `"5min"`)
+  - String values (e.g., `"public,app_schema"`)
+  - Complex values that need proper escaping
+
+- **`quote = false`**: Use for:
+  - Numeric values without units (e.g., `4`, `100`, `30000`)
+  - Boolean-like numeric values (e.g., `0`, `1`)
+
+## Usage
+
+1. Configure your PostgreSQL provider connection details in `main.tf`
+2. Initialize Terraform:
+   ```bash
+   terraform init
+   ```
+3. Plan the changes:
+   ```bash
+   terraform plan
+   ```
+4. Apply the configuration:
+   ```bash
+   terraform apply
+   ```
+
+## Verifying the Configuration
+
+After applying, you can verify the database parameters are set correctly:
+
+```sql
+-- Connect to the database
+\c myapp_db
+
+-- Show all database-specific parameters
+SELECT name, setting 
+FROM pg_db_role_setting s
+JOIN pg_database d ON d.oid = s.setdatabase
+WHERE d.datname = 'myapp_db';
+
+-- Or check a specific parameter
+SHOW work_mem;
+```
+
+## Notes
+
+- The `quote` parameter controls whether the value should be quoted as a string literal
+- Set `quote = false` for numeric values and identifiers
+- Set `quote = true` (default) for string values
+- Parameters set at the database level override server-level defaults for connections to that database
+

--- a/examples/database-with-parameters/main.tf
+++ b/examples/database-with-parameters/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  required_providers {
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+    }
+  }
+}
+
+provider "postgresql" {
+  host            = "localhost"
+  port            = 5432
+  username        = "postgres"
+  password        = "postgres"
+  sslmode         = "disable"
+  connect_timeout = 15
+}
+
+# Create the role that will own the database
+resource "postgresql_role" "myapp_owner" {
+  name  = "myapp_owner"
+  login = true
+
+  parameter {
+    name  = "idle_session_timeout"
+    value = "50000"
+    quote = false
+  }
+}
+
+# Create a database with configuration parameters
+resource "postgresql_database" "app_db" {
+  name              = "myapp_db"
+  owner             = postgresql_role.myapp_owner.name
+  connection_limit  = 100
+  allow_connections = true
+
+  # Set max parallel workers
+  parameter {
+    name  = "max_parallel_workers"
+    value = "4"
+    quote = false
+  }
+
+  # Set statement timeout (in milliseconds)
+  parameter {
+    name  = "statement_timeout"
+    value = "40000"
+    quote = false
+  }
+
+  # Set default statistics target
+  parameter {
+    name  = "default_statistics_target"
+    value = "100"
+    quote = false
+  }
+}
+
+# Example with a quoted string parameter
+resource "postgresql_database" "app_db_with_search_path" {
+  name = "myapp_db2"
+
+  # Set custom search path
+  parameter {
+    name  = "search_path"
+    value = "public,app_schema"
+  }
+}
+

--- a/website/docs/r/postgresql_database.html.markdown
+++ b/website/docs/r/postgresql_database.html.markdown
@@ -24,6 +24,18 @@ resource "postgresql_database" "my_db" {
   connection_limit       = -1
   allow_connections      = true
   alter_object_ownership = true
+
+  parameter {
+    name  = "work_mem"
+    value = "16MB"
+    quote = false
+  }
+
+  parameter {
+    name  = "max_parallel_workers"
+    value = "4"
+    quote = false
+  }
 }
 ```
 
@@ -90,6 +102,14 @@ resource "postgresql_database" "my_db" {
   hold the ownership of the objects in that database. To alter existing objects in
   the database, you must be a direct or indirect member of the specified role, or
   the username in the provider must be superuser.
+
+* `parameter` - (Optional) A configuration block for setting database-level
+  configuration parameters. Can be specified multiple times. Each block supports
+  the following:
+  * `name` - (Required) The name of the configuration parameter to set.
+  * `value` - (Required) The value of the configuration parameter.
+  * `quote` - (Optional) Whether to quote the parameter value. Defaults to `true`.
+    Set to `false` for numeric or unquoted values.
 
 ## Import Example
 


### PR DESCRIPTION
## Description

This PR adds support for database-level configuration parameters to the `postgresql_database` resource, similar to what was implemented for roles in commit f625d092.

## Changes

### Core Implementation (`resource_postgresql_database.go`)
- Added `parameter` block to database schema with `name`, `value`, and `quote` attributes
- Implemented `readDatabaseParameters()` to read parameters from `pg_database.datconfig`
- Implemented `setDatabaseConfigurationParameters()` to apply changes via `ALTER DATABASE SET/RESET`
- Updated `resourcePostgreSQLDatabaseReadImpl()` to read parameters
- Updated `resourcePostgreSQLDatabaseUpdate()` to set parameters

### Tests (`resource_postgresql_database_test.go`)
- Added `TestAccPostgresqlDatabase_Parameters` test covering:
  - Database creation with multiple parameters
  - Parameter updates and deletions
- Added `testAccCheckDatabaseParameter()` helper function

### Documentation
- Updated `website/docs/r/postgresql_database.html.markdown` with:
  - Usage examples with `parameter` blocks
  - Complete documentation in "Argument Reference" section
- Added `examples/database-with-parameters/` with practical examples

## Usage Example

```hcl
resource "postgresql_database" "my_db" {
  name = "my_db"

  parameter {
    name  = "work_mem"
    value = "16MB"
    quote = false
  }

  parameter {
    name  = "max_parallel_workers"
    value = "4"
    quote = false
  }
}
```

## Generated SQL

### Set parameter
```sql
ALTER DATABASE my_db SET work_mem TO 16MB;
```

### Reset parameter
```sql
ALTER DATABASE my_db RESET work_mem;
```

## Compatibility

- Compatible with all PostgreSQL versions supported by the provider
- Database-level configuration parameters are available since PostgreSQL 9.0+