### PR TITLE
Allow configuring maximum idle connections

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -179,6 +179,7 @@ type Config struct {
 	Timeout                         int
 	ConnectTimeoutSec               int
 	MaxConns                        int
+	MaxIDleConns                    int
 	ExpectedVersion                 semver.Version
 	SSLClientCert                   *ClientCertificateConfig
 	SSLRootCertPath                 string
@@ -305,10 +306,7 @@ func (c *Client) Connect() (*DBConnection, error) {
 			return nil, fmt.Errorf("error connecting to PostgreSQL server %s (scheme: %s): %s", c.config.Host, c.config.Scheme, errString)
 		}
 
-		// We don't want to retain connection
-		// So when we connect on a specific database which might be managed by terraform,
-		// we don't keep opened connection in case of the db has to be dropped in the plan.
-		db.SetMaxIdleConns(0)
+		db.SetMaxIdleConns(c.config.MaxIDleConns)
 		db.SetMaxOpenConns(c.config.MaxConns)
 
 		defaultVersion, _ := semver.Parse(defaultExpectedPostgreSQLVersion)

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -183,6 +183,7 @@ type Config struct {
 	Timeout                         int
 	ConnectTimeoutSec               int
 	MaxConns                        int
+	MaxIdleConns                    int
 	ExpectedVersion                 semver.Version
 	SSLClientCert                   *ClientCertificateConfig
 	SSLRootCertPath                 string
@@ -309,10 +310,7 @@ func (c *Client) Connect() (*DBConnection, error) {
 			return nil, fmt.Errorf("error connecting to PostgreSQL server %s (scheme: %s): %s", c.config.Host, c.config.Scheme, errString)
 		}
 
-		// We don't want to retain connection
-		// So when we connect on a specific database which might be managed by terraform,
-		// we don't keep opened connection in case of the db has to be dropped in the plan.
-		db.SetMaxIdleConns(0)
+		db.SetMaxIdleConns(c.config.MaxIdleConns)
 		db.SetMaxOpenConns(c.config.MaxConns)
 
 		defaultVersion, _ := semver.Parse(defaultExpectedPostgreSQLVersion)

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -192,6 +192,13 @@ func Provider() *schema.Provider {
 				Description:  "Maximum number of connections to establish to the database. Zero means unlimited.",
 				ValidateFunc: validation.IntAtLeast(-1),
 			},
+			"max_idle_connections": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      0,
+				Description:  "Maximum number of idle connections. Zero means no idle connections, useful when Db is managed in the same terraform state.",
+				ValidateFunc: validation.IntAtLeast(-1),
+			},
 			"expected_version": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -383,6 +390,7 @@ func providerConfigure(d *schema.ResourceData) (any, error) {
 		ApplicationName:                 "Terraform provider",
 		ConnectTimeoutSec:               d.Get("connect_timeout").(int),
 		MaxConns:                        d.Get("max_connections").(int),
+		MaxIDleConns:                    d.Get("max_idle_connections").(int),
 		ExpectedVersion:                 version,
 		SSLRootCertPath:                 d.Get("sslrootcert").(string),
 		GCPIAMImpersonateServiceAccount: d.Get("gcp_iam_impersonate_service_account").(string),

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -192,6 +192,13 @@ func Provider() *schema.Provider {
 				Description:  "Maximum number of connections to establish to the database. Zero means unlimited.",
 				ValidateFunc: validation.IntAtLeast(-1),
 			},
+			"max_idle_connections": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      0,
+				Description:  "Maximum number of idle connections. Zero or negative means no idle connections are retained, which is useful when the DB is managed in the same Terraform state. The default is 0.",
+				ValidateFunc: validation.IntAtLeast(-1),
+			},
 			"expected_version": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -383,6 +390,7 @@ func providerConfigure(d *schema.ResourceData) (any, error) {
 		ApplicationName:                 "Terraform provider",
 		ConnectTimeoutSec:               d.Get("connect_timeout").(int),
 		MaxConns:                        d.Get("max_connections").(int),
+		MaxIdleConns:                    d.Get("max_idle_connections").(int),
 		ExpectedVersion:                 version,
 		SSLRootCertPath:                 d.Get("sslrootcert").(string),
 		GCPIAMImpersonateServiceAccount: d.Get("gcp_iam_impersonate_service_account").(string),

--- a/postgresql/provider_test.go
+++ b/postgresql/provider_test.go
@@ -29,6 +29,31 @@ func TestProvider_impl(t *testing.T) {
 	var _ = Provider()
 }
 
+func TestProviderConfigureMaxIdleConnections(t *testing.T) {
+	raw := map[string]interface{}{
+		"host":                 "localhost",
+		"port":                 5432,
+		"username":             "postgres",
+		"max_idle_connections": 7,
+	}
+
+	d := schema.TestResourceDataRaw(t, Provider().Schema, raw)
+
+	meta, err := providerConfigure(d)
+	if err != nil {
+		t.Fatalf("providerConfigure returned an error: %s", err)
+	}
+
+	client, ok := meta.(*Client)
+	if !ok {
+		t.Fatalf("expected *Client, got %T", meta)
+	}
+
+	if client.config.MaxIdleConns != 7 {
+		t.Errorf("expected MaxIdleConns to be 7, got %d", client.config.MaxIdleConns)
+	}
+}
+
 func testAccPreCheck(t *testing.T) {
 	var host string
 	if host = os.Getenv("PGHOST"); host == "" {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -172,6 +172,8 @@ The following arguments are supported:
   default is `180s`.  Zero or not specified means wait indefinitely.
 * `max_connections` - (Optional) Set the maximum number of open connections to
   the database. The default is `20`.  Zero means unlimited open connections.
+* `max_idle_connections` - (Optional) Maximum number of idle connections. 
+  Zero means no idle connections, useful when Db is managed in the same terraform state. The default is `0`.
 * `expected_version` - (Optional) Specify a hint to Terraform regarding the
   expected version that the provider will be talking with.  This is a required
   hint in order for Terraform to talk with an ancient version of PostgreSQL.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -172,6 +172,8 @@ The following arguments are supported:
   default is `180s`.  Zero or not specified means wait indefinitely.
 * `max_connections` - (Optional) Set the maximum number of open connections to
   the database. The default is `20`.  Zero means unlimited open connections.
+* `max_idle_connections` - (Optional) Maximum number of idle connections.
+  Zero or negative means no idle connections are retained, which is useful when the DB is managed in the same Terraform state. The default is `0`.
 * `expected_version` - (Optional) Specify a hint to Terraform regarding the
   expected version that the provider will be talking with.  This is a required
   hint in order for Terraform to talk with an ancient version of PostgreSQL.


### PR DESCRIPTION
This PR adds support for configuring the maximum number of idle connections in the PostgreSQL connection pool.

## Changes
- Added `MaxIDleConns` field to the `Config` struct
- Configured `SetMaxIdleConns` on the database connection using the new parameter
- Allows better control over connection pool behavior and resource management

## Context
This enhancement provides more flexibility in managing database connections, particularly useful for optimizing performance in huge ressources contexts