### PR TITLE
feat: Add aws_rds_endpoint option to use a different endpoint for token signature

### DIFF
--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -78,6 +78,14 @@ func Provider() *schema.Provider {
 					"(see: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)",
 			},
 
+			"aws_rds_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				Description: "Use this endpoint instead of the host when generating the authentication token. " +
+					"This is useful when using a different hostname for connection to connect through a proxy or VPN.",
+			},
+
 			"aws_rds_iam_profile": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -236,8 +244,10 @@ func validateExpectedVersion(v any, key string) (warnings []string, errors []err
 	return
 }
 
-func getRDSAuthToken(region string, profile string, role string, username string, host string, port int) (string, error) {
-	endpoint := fmt.Sprintf("%s:%d", host, port)
+func getRDSAuthToken(region string, profile string, role string, username string, endpoint string, host string, port int) (string, error) {
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("%s:%d", host, port)
+	}
 
 	ctx := context.Background()
 
@@ -351,9 +361,10 @@ func providerConfigure(d *schema.ResourceData) (any, error) {
 	if d.Get("aws_rds_iam_auth").(bool) {
 		profile := d.Get("aws_rds_iam_profile").(string)
 		region := d.Get("aws_rds_iam_region").(string)
+		endpoint := d.Get("aws_rds_endpoint").(string)
 		role := d.Get("aws_rds_iam_provider_role_arn").(string)
 		var err error
-		password, err = getRDSAuthToken(region, profile, role, username, host, port)
+		password, err = getRDSAuthToken(region, profile, role, username, endpoint, host, port)
 		if err != nil {
 			return nil, err
 		}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -184,6 +184,7 @@ The following arguments are supported:
 * `aws_rds_iam_profile` - (Optional) The AWS IAM Profile to use while using AWS RDS IAM Auth.
 * `aws_rds_iam_region` - (Optional) The AWS region to use while using AWS RDS IAM Auth.
 * `aws_rds_iam_provider_role_arn` - (Optional) AWS IAM role to assume while using AWS RDS IAM Auth.
+* `aws_rds_endpoint` - (Optional) The RDS endpoint used instead of the host to generate the authentication token. This is useful when using a different hostname for connection to connect through a proxy or VPN.
 * `azure_identity_auth` - (Optional) If set to `true`, call the Azure OAuth token endpoint for temporary token
 * `azure_tenant_id` - (Optional) (Required if `azure_identity_auth` is `true`) Azure tenant ID [read more](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config.html)
 


### PR DESCRIPTION
For example, we do connect to our RDS instance through a different hostname (Tailscale, or K8s service), but still need to use the original RDS endpoint for signature.

This option allow to set the Host to the connection host and Endpoint as the signature endpoint.