### PR TITLE
Add support for MAINTAIN permission when using "ALL" for pg16+

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -46,6 +46,7 @@ const (
 	featureServer
 	featureCreateRoleSelfGrant
 	featureSecurityLabel
+	featurePrivilegeMaintain
 )
 
 var (
@@ -122,6 +123,9 @@ var (
 		// https://www.postgresql.org/docs/16/release-16.html#RELEASE-16-PRIVILEGES
 		featureCreateRoleSelfGrant: semver.MustParseRange(">=16.0.0"),
 		featureSecurityLabel:       semver.MustParseRange(">=11.0.0"),
+
+		// MAINTAIN privilege for tables (VACUUM, ANALYZE, REINDEX, etc.)
+		featurePrivilegeMaintain: semver.MustParseRange(">=16.0.0"),
 	}
 )
 

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -124,8 +124,11 @@ var (
 		featureCreateRoleSelfGrant: semver.MustParseRange(">=16.0.0"),
 		featureSecurityLabel:       semver.MustParseRange(">=11.0.0"),
 
-		// MAINTAIN privilege for tables (VACUUM, ANALYZE, REINDEX, etc.)
-		featurePrivilegeMaintain: semver.MustParseRange(">=16.0.0"),
+		// MAINTAIN privilege for tables (VACUUM, ANALYZE, REINDEX, etc.).
+		// It was briefly added during PostgreSQL 16 development but reverted,
+		// and finally shipped in PostgreSQL 17.
+		// https://www.postgresql.org/docs/17/release-17.html
+		featurePrivilegeMaintain: semver.MustParseRange(">=17.0.0"),
 	}
 )
 

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/lib/pq"
 )
@@ -251,7 +252,7 @@ func sliceContainsStr(haystack []string, needle string) bool {
 // see: https://www.postgresql.org/docs/current/sql-grant.html
 var allowedPrivileges = map[string][]string{
 	"database":             {"ALL", "CREATE", "CONNECT", "TEMPORARY"},
-	"table":                {"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"},
+	"table":                {"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"},
 	"sequence":             {"ALL", "USAGE", "SELECT", "UPDATE"},
 	"schema":               {"ALL", "CREATE", "USAGE"},
 	"function":             {"ALL", "EXECUTE"},
@@ -281,7 +282,26 @@ func validatePrivileges(d *schema.ResourceData) error {
 	return nil
 }
 
-func resourcePrivilegesEqual(granted *schema.Set, d *schema.ResourceData) bool {
+// allPrivilegesForObjectType returns the individual privileges that ALL
+// expands to for the given object type and server version.
+func allPrivilegesForObjectType(objectType string, ver semver.Version) []string {
+	base := allowedPrivileges[objectType]
+	maintainRange := featureSupported[featurePrivilegeMaintain]
+
+	var privs []string
+	for _, p := range base {
+		if p == "ALL" {
+			continue
+		}
+		if p == "MAINTAIN" && !maintainRange(ver) {
+			continue
+		}
+		privs = append(privs, p)
+	}
+	return privs
+}
+
+func resourcePrivilegesEqual(granted *schema.Set, d *schema.ResourceData, ver semver.Version) bool {
 	objectType := d.Get("object_type").(string)
 	wanted := d.Get("privileges").(*schema.Set)
 
@@ -293,13 +313,10 @@ func resourcePrivilegesEqual(granted *schema.Set, d *schema.ResourceData) bool {
 		return false
 	}
 
-	// implicit check: e.g. for object_type schema -> ALL == ["CREATE", "USAGE"]
 	log.Printf("The wanted privilege is 'ALL'. therefore, we will check if the current privileges are ALL implicitly")
-	implicits := []any{}
-	for _, p := range allowedPrivileges[objectType] {
-		if p != "ALL" {
-			implicits = append(implicits, p)
-		}
+	implicits := make([]any, 0)
+	for _, p := range allPrivilegesForObjectType(objectType, ver) {
+		implicits = append(implicits, p)
 	}
 	wantedSet := schema.NewSet(schema.HashString, implicits)
 	return granted.Equal(wantedSet)

--- a/postgresql/helpers_test.go
+++ b/postgresql/helpers_test.go
@@ -1,9 +1,10 @@
 package postgresql
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"testing"
 
+	"github.com/blang/semver"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,59 +48,104 @@ func TestQuoteTableName(t *testing.T) {
 	}
 }
 
+var (
+	pg15 = semver.MustParse("15.0.0")
+	pg16 = semver.MustParse("16.0.0")
+)
+
 func TestArePrivilegesEqual(t *testing.T) {
 
 	type PrivilegesTestObject struct {
+		name      string
 		d         *schema.ResourceData
 		granted   *schema.Set
 		wanted    *schema.Set
+		ver       semver.Version
 		assertion bool
 	}
 
 	tt := []PrivilegesTestObject{
 		{
+			"database ALL on pg15",
 			buildResourceData("database", t),
 			buildPrivilegesSet("CONNECT", "CREATE", "TEMPORARY"),
 			buildPrivilegesSet("ALL"),
+			pg15,
 			true,
 		},
 		{
+			"database partial != USAGE",
 			buildResourceData("database", t),
 			buildPrivilegesSet("CREATE", "USAGE"),
 			buildPrivilegesSet("USAGE"),
+			pg15,
 			false,
 		},
 		{
+			"table ALL without MAINTAIN on pg15",
 			buildResourceData("table", t),
 			buildPrivilegesSet("SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"),
 			buildPrivilegesSet("ALL"),
+			pg15,
 			true,
 		},
 		{
+			"table ALL with MAINTAIN on pg16",
 			buildResourceData("table", t),
-			buildPrivilegesSet("SELECT"),
-			buildPrivilegesSet("SELECT, INSERT"),
+			buildPrivilegesSet("SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"),
+			buildPrivilegesSet("ALL"),
+			pg16,
+			true,
+		},
+		{
+			"table MAINTAIN in granted but pg15 expects no MAINTAIN - should drift",
+			buildResourceData("table", t),
+			buildPrivilegesSet("SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"),
+			buildPrivilegesSet("ALL"),
+			pg15,
 			false,
 		},
 		{
+			"table ALL missing MAINTAIN on pg16 - should drift",
+			buildResourceData("table", t),
+			buildPrivilegesSet("SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"),
+			buildPrivilegesSet("ALL"),
+			pg16,
+			false,
+		},
+		{
+			"table partial != multi",
+			buildResourceData("table", t),
+			buildPrivilegesSet("SELECT"),
+			buildPrivilegesSet("SELECT, INSERT"),
+			pg15,
+			false,
+		},
+		{
+			"schema ALL on pg15",
 			buildResourceData("schema", t),
 			buildPrivilegesSet("CREATE", "USAGE"),
 			buildPrivilegesSet("ALL"),
+			pg15,
 			true,
 		},
 		{
+			"schema partial != ALL",
 			buildResourceData("schema", t),
 			buildPrivilegesSet("CREATE"),
 			buildPrivilegesSet("ALL"),
+			pg15,
 			false,
 		},
 	}
 
-	for _, configuration := range tt {
-		err := configuration.d.Set("privileges", configuration.wanted)
-		assert.NoError(t, err)
-		equal := resourcePrivilegesEqual(configuration.granted, configuration.d)
-		assert.Equal(t, configuration.assertion, equal)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.d.Set("privileges", tc.wanted)
+			assert.NoError(t, err)
+			equal := resourcePrivilegesEqual(tc.granted, tc.d, tc.ver)
+			assert.Equal(t, tc.assertion, equal)
+		})
 	}
 }
 

--- a/postgresql/helpers_test.go
+++ b/postgresql/helpers_test.go
@@ -51,6 +51,7 @@ func TestQuoteTableName(t *testing.T) {
 var (
 	pg15 = semver.MustParse("15.0.0")
 	pg16 = semver.MustParse("16.0.0")
+	pg17 = semver.MustParse("17.0.0")
 )
 
 func TestArePrivilegesEqual(t *testing.T) {
@@ -90,27 +91,35 @@ func TestArePrivilegesEqual(t *testing.T) {
 			true,
 		},
 		{
-			"table ALL with MAINTAIN on pg16",
+			"table ALL without MAINTAIN on pg16",
 			buildResourceData("table", t),
-			buildPrivilegesSet("SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"),
+			buildPrivilegesSet("SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"),
 			buildPrivilegesSet("ALL"),
 			pg16,
 			true,
 		},
 		{
-			"table MAINTAIN in granted but pg15 expects no MAINTAIN - should drift",
+			"table ALL with MAINTAIN on pg17",
 			buildResourceData("table", t),
 			buildPrivilegesSet("SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"),
 			buildPrivilegesSet("ALL"),
-			pg15,
+			pg17,
+			true,
+		},
+		{
+			"table MAINTAIN in granted but pg16 expects no MAINTAIN - should drift",
+			buildResourceData("table", t),
+			buildPrivilegesSet("SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"),
+			buildPrivilegesSet("ALL"),
+			pg16,
 			false,
 		},
 		{
-			"table ALL missing MAINTAIN on pg16 - should drift",
+			"table ALL missing MAINTAIN on pg17 - should drift",
 			buildResourceData("table", t),
 			buildPrivilegesSet("SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"),
 			buildPrivilegesSet("ALL"),
-			pg16,
+			pg17,
 			false,
 		},
 		{

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -110,7 +111,7 @@ func resourcePostgreSQLDefaultPrivilegesRead(db *DBConnection, d *schema.Resourc
 	}
 	defer deferredRollback(txn)
 
-	return readRoleDefaultPrivileges(txn, d)
+	return readRoleDefaultPrivileges(txn, db.version, d)
 }
 
 func resourcePostgreSQLDefaultPrivilegesCreate(db *DBConnection, d *schema.ResourceData) error {
@@ -185,7 +186,7 @@ func resourcePostgreSQLDefaultPrivilegesCreate(db *DBConnection, d *schema.Resou
 	}
 	defer deferredRollback(txn)
 
-	return readRoleDefaultPrivileges(txn, d)
+	return readRoleDefaultPrivileges(txn, db.version, d)
 }
 
 func resourcePostgreSQLDefaultPrivilegesDelete(db *DBConnection, d *schema.ResourceData) error {
@@ -224,7 +225,7 @@ func resourcePostgreSQLDefaultPrivilegesDelete(db *DBConnection, d *schema.Resou
 	return nil
 }
 
-func readRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+func readRoleDefaultPrivileges(txn *sql.Tx, ver semver.Version, d *schema.ResourceData) error {
 	role := d.Get("role").(string)
 	owner := d.Get("owner").(string)
 	pgSchema := d.Get("schema").(string)
@@ -283,7 +284,7 @@ func readRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 	}
 
 	privilegesSet := pgArrayToSet(privileges)
-	privilegesEqual := resourcePrivilegesEqual(privilegesSet, d)
+	privilegesEqual := resourcePrivilegesEqual(privilegesSet, d, ver)
 
 	if !privilegesEqual {
 		d.Set("privileges", privilegesSet)

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -125,7 +126,7 @@ func resourcePostgreSQLGrantRead(db *DBConnection, d *schema.ResourceData) error
 	}
 	defer deferredRollback(txn)
 
-	return readRolePrivileges(txn, d)
+	return readRolePrivileges(txn, db.version, d)
 }
 
 func resourcePostgreSQLGrantCreate(db *DBConnection, d *schema.ResourceData) error {
@@ -218,7 +219,7 @@ func resourcePostgreSQLGrantCreateOrUpdate(db *DBConnection, d *schema.ResourceD
 	}
 	defer deferredRollback(txn)
 
-	return readRolePrivileges(txn, d)
+	return readRolePrivileges(txn, db.version, d)
 }
 
 func resourcePostgreSQLGrantDelete(db *DBConnection, d *schema.ResourceData) error {
@@ -263,7 +264,7 @@ func resourcePostgreSQLGrantDelete(db *DBConnection, d *schema.ResourceData) err
 	return nil
 }
 
-func readDatabaseRolePrivileges(txn *sql.Tx, d *schema.ResourceData, roleOID uint32) error {
+func readDatabaseRolePrivileges(txn *sql.Tx, ver semver.Version, d *schema.ResourceData, roleOID uint32) error {
 	dbName := d.Get("database").(string)
 	query := `
 SELECT array_agg(privilege_type)
@@ -278,13 +279,13 @@ WHERE grantee = $2
 		return fmt.Errorf("could not read privileges for database %s: %w", dbName, err)
 	}
 	granted := pgArrayToSet(privileges)
-	if !resourcePrivilegesEqual(granted, d) {
+	if !resourcePrivilegesEqual(granted, d, ver) {
 		return d.Set("privileges", granted)
 	}
 	return nil
 }
 
-func readSchemaRolePrivileges(txn *sql.Tx, d *schema.ResourceData, roleOID uint32) error {
+func readSchemaRolePrivileges(txn *sql.Tx, ver semver.Version, d *schema.ResourceData, roleOID uint32) error {
 	dbName := d.Get("schema").(string)
 	query := `
 SELECT array_agg(privilege_type)
@@ -300,13 +301,13 @@ WHERE grantee = $2
 	}
 
 	granted := pgArrayToSet(privileges)
-	if !resourcePrivilegesEqual(granted, d) {
+	if !resourcePrivilegesEqual(granted, d, ver) {
 		return d.Set("privileges", granted)
 	}
 	return nil
 }
 
-func readForeignDataWrapperRolePrivileges(txn *sql.Tx, d *schema.ResourceData, roleOID uint32) error {
+func readForeignDataWrapperRolePrivileges(txn *sql.Tx, ver semver.Version, d *schema.ResourceData, roleOID uint32) error {
 	objects := d.Get("objects").(*schema.Set).List()
 	fdwName := objects[0].(string)
 	query := `
@@ -323,13 +324,13 @@ WHERE grantee = $2
 	}
 
 	granted := pgArrayToSet(privileges)
-	if !resourcePrivilegesEqual(granted, d) {
+	if !resourcePrivilegesEqual(granted, d, ver) {
 		return d.Set("privileges", granted)
 	}
 	return nil
 }
 
-func readForeignServerRolePrivileges(txn *sql.Tx, d *schema.ResourceData, roleOID uint32) error {
+func readForeignServerRolePrivileges(txn *sql.Tx, ver semver.Version, d *schema.ResourceData, roleOID uint32) error {
 	objects := d.Get("objects").(*schema.Set).List()
 	srvName := objects[0].(string)
 	query := `
@@ -346,7 +347,7 @@ WHERE grantee = $2
 	}
 
 	granted := pgArrayToSet(privileges)
-	if !resourcePrivilegesEqual(granted, d) {
+	if !resourcePrivilegesEqual(granted, d, ver) {
 		return d.Set("privileges", granted)
 	}
 	return nil
@@ -430,7 +431,7 @@ ORDER BY col_privs.attname
 	return nil
 }
 
-func readRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+func readRolePrivileges(txn *sql.Tx, ver semver.Version, d *schema.ResourceData) error {
 	role := d.Get("role").(string)
 	objectType := d.Get("object_type").(string)
 	objects := d.Get("objects").(*schema.Set)
@@ -445,16 +446,16 @@ func readRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 
 	switch objectType {
 	case "database":
-		return readDatabaseRolePrivileges(txn, d, roleOID)
+		return readDatabaseRolePrivileges(txn, ver, d, roleOID)
 
 	case "schema":
-		return readSchemaRolePrivileges(txn, d, roleOID)
+		return readSchemaRolePrivileges(txn, ver, d, roleOID)
 
 	case "foreign_data_wrapper":
-		return readForeignDataWrapperRolePrivileges(txn, d, roleOID)
+		return readForeignDataWrapperRolePrivileges(txn, ver, d, roleOID)
 
 	case "foreign_server":
-		return readForeignServerRolePrivileges(txn, d, roleOID)
+		return readForeignServerRolePrivileges(txn, ver, d, roleOID)
 
 	case "function", "procedure", "routine":
 		query = `
@@ -521,7 +522,7 @@ GROUP BY pg_class.relname
 		}
 
 		privilegesSet := pgArrayToSet(privileges)
-		if !resourcePrivilegesEqual(privilegesSet, d) {
+		if !resourcePrivilegesEqual(privilegesSet, d, ver) {
 			// If any object doesn't have the same privileges as saved in the state,
 			// we return its privileges to force an update.
 			log.Printf(


### PR DESCRIPTION
Adds support to avoid drifts when using "ALL" with pg16+ which added MAINTAIN.

I've compiled the provider and used locally against our use cases where using "ALL" is causing drift due to MAINTAIN permissions with pg17, and confirmed no drift caused against our pg15 resources using "ALL".