### PR TITLE
feat: add MAINTAIN privilege support for table object type

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -251,7 +251,7 @@ func sliceContainsStr(haystack []string, needle string) bool {
 // see: https://www.postgresql.org/docs/current/sql-grant.html
 var allowedPrivileges = map[string][]string{
 	"database":             {"ALL", "CREATE", "CONNECT", "TEMPORARY"},
-	"table":                {"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"},
+	"table":                {"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"},
 	"sequence":             {"ALL", "USAGE", "SELECT", "UPDATE"},
 	"schema":               {"ALL", "CREATE", "USAGE"},
 	"function":             {"ALL", "EXECUTE"},


### PR DESCRIPTION
## Summary

PostgreSQL 16 introduced the `MAINTAIN` privilege for tables ([docs](https://www.postgresql.org/docs/16/sql-grant.html)), which allows non-owner roles to perform:

- `REINDEX`
- `VACUUM`
- `ANALYZE`
- `CLUSTER`
- `LOCK TABLE`
- `REFRESH MATERIALIZED VIEW`

This is useful for granting maintenance operations to application roles without requiring table ownership or superuser access.

## Changes

Added `MAINTAIN` to the `allowedPrivileges` map for `table` object type in `helpers.go`.

## Usage example

```hcl
resource "postgresql_grant" "app_maintain" {
  database    = "mydb"
  role        = "app_role"
  schema      = "public"
  object_type = "table"
  privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE", "MAINTAIN"]
}

resource "postgresql_default_privileges" "app_maintain" {
  role        = "app_role"
  database    = "mydb"
  schema      = "public"
  owner       = "postgres"
  object_type = "table"
  privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE", "MAINTAIN"]
}
```

## Testing

- [x] `go build ./...` passes
- [x] `TestCreateGrantQuery` unit test passes
- [ ] Acceptance tests with PostgreSQL 16+ (requires PG 16+ instance)

> **Note:** On PostgreSQL versions < 16, the `GRANT MAINTAIN` SQL statement will be rejected by the database server itself, which is the expected behavior — consistent with how other privileges work when applied to unsupported versions.