### PR TITLE
Add postgresql_role_database_setting resource

### DIFF
--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -213,6 +213,7 @@ func Provider() *schema.Provider {
 			"postgresql_physical_replication_slot": resourcePostgreSQLPhysicalReplicationSlot(),
 			"postgresql_schema":                    resourcePostgreSQLSchema(),
 			"postgresql_role":                      resourcePostgreSQLRole(),
+			"postgresql_role_database_setting":     resourcePostgreSQLRoleDatabaseSetting(),
 			"postgresql_function":                  resourcePostgreSQLFunction(),
 			"postgresql_server":                    resourcePostgreSQLServer(),
 			"postgresql_user_mapping":              resourcePostgreSQLUserMapping(),

--- a/postgresql/resource_postgresql_role_database_setting.go
+++ b/postgresql/resource_postgresql_role_database_setting.go
@@ -1,0 +1,301 @@
+package postgresql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/lib/pq"
+)
+
+// PostgreSQL stores all per-database settings for a given (role, database)
+// pair in a single row of pg_db_role_setting (unique on (setdatabase, setrole)).
+// Concurrent ALTER ROLE … IN DATABASE … SET statements that target the same
+// pair race on this unique constraint, so we serialize them with an advisory
+// lock keyed by (role, database).
+const acquireRoleDatabaseSettingLockSQL = `SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))`
+
+const (
+	roleDatabaseSettingRoleAttr      = "role"
+	roleDatabaseSettingDatabaseAttr  = "database"
+	roleDatabaseSettingParameterAttr = "parameter"
+	roleDatabaseSettingValueAttr     = "value"
+)
+
+func resourcePostgreSQLRoleDatabaseSetting() *schema.Resource {
+	return &schema.Resource{
+		Create: PGResourceFunc(resourcePostgreSQLRoleDatabaseSettingCreate),
+		Read:   PGResourceFunc(resourcePostgreSQLRoleDatabaseSettingRead),
+		Update: PGResourceFunc(resourcePostgreSQLRoleDatabaseSettingUpdate),
+		Delete: PGResourceFunc(resourcePostgreSQLRoleDatabaseSettingDelete),
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePostgreSQLRoleDatabaseSettingImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			roleDatabaseSettingRoleAttr: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The role whose per-database setting is managed (ALTER ROLE <role>).",
+			},
+			roleDatabaseSettingDatabaseAttr: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The database in which the setting applies (IN DATABASE <database>).",
+			},
+			roleDatabaseSettingParameterAttr: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The configuration parameter to set (e.g. role, search_path, statement_timeout).",
+			},
+			roleDatabaseSettingValueAttr: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The value to assign to the parameter for this (role, database) pair.",
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLRoleDatabaseSettingCreate(db *DBConnection, d *schema.ResourceData) error {
+	if err := applyRoleDatabaseSetting(db, d); err != nil {
+		return err
+	}
+	d.SetId(generateRoleDatabaseSettingID(d))
+	return resourcePostgreSQLRoleDatabaseSettingReadImpl(db, d)
+}
+
+func resourcePostgreSQLRoleDatabaseSettingUpdate(db *DBConnection, d *schema.ResourceData) error {
+	if err := applyRoleDatabaseSetting(db, d); err != nil {
+		return err
+	}
+	return resourcePostgreSQLRoleDatabaseSettingReadImpl(db, d)
+}
+
+func resourcePostgreSQLRoleDatabaseSettingRead(db *DBConnection, d *schema.ResourceData) error {
+	return resourcePostgreSQLRoleDatabaseSettingReadImpl(db, d)
+}
+
+func resourcePostgreSQLRoleDatabaseSettingDelete(db *DBConnection, d *schema.ResourceData) error {
+	role := d.Get(roleDatabaseSettingRoleAttr).(string)
+	database := d.Get(roleDatabaseSettingDatabaseAttr).(string)
+	parameter := d.Get(roleDatabaseSettingParameterAttr).(string)
+
+	// If role or database has been dropped externally, treat the setting as
+	// already gone — RESET would otherwise fail with "role/database does not exist".
+	exists, err := roleAndDatabaseExist(db, role, database)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		log.Printf("[WARN] PostgreSQL role %q or database %q no longer exists; skipping RESET %s", role, database, parameter)
+		d.SetId("")
+		return nil
+	}
+
+	txn, err := startTransaction(db.client, "")
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	if _, err := txn.Exec(acquireRoleDatabaseSettingLockSQL, role, database); err != nil {
+		return fmt.Errorf("could not acquire role-database-setting lock: %w", err)
+	}
+
+	stmt := fmt.Sprintf(
+		"ALTER ROLE %s IN DATABASE %s RESET %s",
+		pq.QuoteIdentifier(role),
+		pq.QuoteIdentifier(database),
+		pq.QuoteIdentifier(parameter),
+	)
+	if _, err := txn.Exec(stmt); err != nil {
+		return fmt.Errorf("could not reset %s for role %q in database %q: %w", parameter, role, database, err)
+	}
+	if err := txn.Commit(); err != nil {
+		return fmt.Errorf("could not commit role-database-setting reset: %w", err)
+	}
+	d.SetId("")
+	return nil
+}
+
+func applyRoleDatabaseSetting(db *DBConnection, d *schema.ResourceData) error {
+	role := d.Get(roleDatabaseSettingRoleAttr).(string)
+	database := d.Get(roleDatabaseSettingDatabaseAttr).(string)
+	parameter := d.Get(roleDatabaseSettingParameterAttr).(string)
+	value := d.Get(roleDatabaseSettingValueAttr).(string)
+
+	txn, err := startTransaction(db.client, "")
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	if _, err := txn.Exec(acquireRoleDatabaseSettingLockSQL, role, database); err != nil {
+		return fmt.Errorf("could not acquire role-database-setting lock: %w", err)
+	}
+
+	stmt := fmt.Sprintf(
+		"ALTER ROLE %s IN DATABASE %s SET %s = %s",
+		pq.QuoteIdentifier(role),
+		pq.QuoteIdentifier(database),
+		pq.QuoteIdentifier(parameter),
+		pq.QuoteLiteral(value),
+	)
+	if _, err := txn.Exec(stmt); err != nil {
+		return fmt.Errorf("could not set %s for role %q in database %q: %w", parameter, role, database, err)
+	}
+	if err := txn.Commit(); err != nil {
+		return fmt.Errorf("could not commit role-database-setting update: %w", err)
+	}
+	return nil
+}
+
+func resourcePostgreSQLRoleDatabaseSettingReadImpl(db *DBConnection, d *schema.ResourceData) error {
+	role := d.Get(roleDatabaseSettingRoleAttr).(string)
+	database := d.Get(roleDatabaseSettingDatabaseAttr).(string)
+	parameter := d.Get(roleDatabaseSettingParameterAttr).(string)
+
+	const query = `
+SELECT s.setconfig
+FROM pg_db_role_setting s
+JOIN pg_roles r ON r.oid = s.setrole
+JOIN pg_database dbs ON dbs.oid = s.setdatabase
+WHERE r.rolname = $1 AND dbs.datname = $2
+`
+	var setconfig []string
+	err := db.QueryRow(query, role, database).Scan(pq.Array(&setconfig))
+	switch {
+	case err == sql.ErrNoRows:
+		log.Printf("[WARN] no pg_db_role_setting row for role %q in database %q", role, database)
+		d.SetId("")
+		return nil
+	case err != nil:
+		return fmt.Errorf("error reading role database setting: %w", err)
+	}
+
+	value, found := findSetconfigValue(setconfig, parameter)
+	if !found {
+		log.Printf("[WARN] parameter %q not found in setconfig for role %q in database %q", parameter, role, database)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set(roleDatabaseSettingRoleAttr, role)
+	d.Set(roleDatabaseSettingDatabaseAttr, database)
+	d.Set(roleDatabaseSettingParameterAttr, parameter)
+	d.Set(roleDatabaseSettingValueAttr, value)
+	d.SetId(generateRoleDatabaseSettingID(d))
+	return nil
+}
+
+// findSetconfigValue searches a pg_db_role_setting.setconfig array (each
+// element formatted as "key=value") for the requested parameter and returns
+// the unquoted value. Parameter name comparison is case-insensitive because
+// PostgreSQL canonicalizes GUC names to lowercase in the catalog.
+func findSetconfigValue(setconfig []string, parameter string) (string, bool) {
+	target := strings.ToLower(parameter)
+	for _, entry := range setconfig {
+		k, v, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if strings.ToLower(k) == target {
+			return stripSetconfigQuotes(v), true
+		}
+	}
+	return "", false
+}
+
+// stripSetconfigQuotes removes the surrounding double quotes that PostgreSQL
+// adds in setconfig when a value contains characters that need quoting
+// (e.g. commas in `search_path="app, public"`). Inside the wrapped form
+// PostgreSQL escapes embedded `"` by doubling it (`""`), so we undo that.
+// Backslash escapes are NOT used at this layer — those belong to the array
+// I/O layer and have already been decoded by pq.Array before we see the
+// element.
+func stripSetconfigQuotes(v string) string {
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		v = v[1 : len(v)-1]
+		v = strings.ReplaceAll(v, `""`, `"`)
+	}
+	return v
+}
+
+func roleAndDatabaseExist(db *DBConnection, role, database string) (bool, error) {
+	var ok bool
+	err := db.QueryRow(
+		`SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)
+		    AND EXISTS(SELECT 1 FROM pg_database WHERE datname = $2)`,
+		role, database,
+	).Scan(&ok)
+	if err != nil {
+		return false, fmt.Errorf("could not check existence of role %q / database %q: %w", role, database, err)
+	}
+	return ok, nil
+}
+
+// generateRoleDatabaseSettingID encodes the (role, database, parameter)
+// triple into a Terraform resource ID. The components are joined with ':',
+// with literal ':' and '\' inside any component backslash-escaped so the ID
+// round-trips for any valid PostgreSQL identifier (which can contain ':'
+// when quoted). Components without these characters round-trip without any
+// visible escaping.
+func generateRoleDatabaseSettingID(d *schema.ResourceData) string {
+	return strings.Join([]string{
+		escapeIDComponent(d.Get(roleDatabaseSettingRoleAttr).(string)),
+		escapeIDComponent(d.Get(roleDatabaseSettingDatabaseAttr).(string)),
+		escapeIDComponent(d.Get(roleDatabaseSettingParameterAttr).(string)),
+	}, ":")
+}
+
+func escapeIDComponent(s string) string {
+	// Order matters: escape backslashes first, then colons, so ':' inserted
+	// here doesn't get re-escaped on the second pass.
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `:`, `\:`)
+	return s
+}
+
+// splitIDComponents splits the encoded ID on un-escaped ':' separators and
+// undoes the backslash escaping applied by escapeIDComponent. It returns
+// however many components are present; callers validate the count.
+func splitIDComponents(id string) []string {
+	var parts []string
+	var cur strings.Builder
+	for i := 0; i < len(id); i++ {
+		if id[i] == '\\' && i+1 < len(id) {
+			cur.WriteByte(id[i+1])
+			i++
+			continue
+		}
+		if id[i] == ':' {
+			parts = append(parts, cur.String())
+			cur.Reset()
+			continue
+		}
+		cur.WriteByte(id[i])
+	}
+	parts = append(parts, cur.String())
+	return parts
+}
+
+func resourcePostgreSQLRoleDatabaseSettingImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	parts := splitIDComponents(d.Id())
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return nil, fmt.Errorf(
+			"invalid postgresql_role_database_setting import ID %q: expected <role>:<database>:<parameter>, with literal ':' and '\\' in any component backslash-escaped (use single quotes in the shell to preserve backslashes)",
+			d.Id(),
+		)
+	}
+	d.Set(roleDatabaseSettingRoleAttr, parts[0])
+	d.Set(roleDatabaseSettingDatabaseAttr, parts[1])
+	d.Set(roleDatabaseSettingParameterAttr, parts[2])
+	return []*schema.ResourceData{d}, nil
+}

--- a/postgresql/resource_postgresql_role_database_setting_test.go
+++ b/postgresql/resource_postgresql_role_database_setting_test.go
@@ -1,0 +1,523 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/lib/pq"
+)
+
+// TestRoleDatabaseSettingIDRoundTrip checks that the composite resource ID
+// encodes and decodes losslessly for identifiers that may legally contain
+// ':' (PostgreSQL allows it in quoted identifiers) and '\'.
+func TestRoleDatabaseSettingIDRoundTrip(t *testing.T) {
+	cases := []struct {
+		name                      string
+		role, database, parameter string
+		wantEncoded               string
+	}{
+		{
+			name:        "no special chars",
+			role:        "alice@example.com",
+			database:    "app_db",
+			parameter:   "role",
+			wantEncoded: "alice@example.com:app_db:role",
+		},
+		{
+			name:        "colon in database",
+			role:        "alice",
+			database:    "app:blue",
+			parameter:   "role",
+			wantEncoded: `alice:app\:blue:role`,
+		},
+		{
+			name:        "colon in role",
+			role:        "alice:dev",
+			database:    "app",
+			parameter:   "role",
+			wantEncoded: `alice\:dev:app:role`,
+		},
+		{
+			name:        "colons in role and database",
+			role:        "alice:dev",
+			database:    "app:blue",
+			parameter:   "role",
+			wantEncoded: `alice\:dev:app\:blue:role`,
+		},
+		{
+			name:        "backslash in role",
+			role:        `weird\name`,
+			database:    "app_db",
+			parameter:   "role",
+			wantEncoded: `weird\\name:app_db:role`,
+		},
+		{
+			name:        "backslash and colon mixed",
+			role:        `with:colon\and\backslash`,
+			database:    "app",
+			parameter:   "role",
+			wantEncoded: `with\:colon\\and\\backslash:app:role`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded := strings.Join([]string{
+				escapeIDComponent(tc.role),
+				escapeIDComponent(tc.database),
+				escapeIDComponent(tc.parameter),
+			}, ":")
+			if encoded != tc.wantEncoded {
+				t.Fatalf("encoded = %q, want %q", encoded, tc.wantEncoded)
+			}
+			parts := splitIDComponents(encoded)
+			if len(parts) != 3 {
+				t.Fatalf("split returned %d parts, want 3: %v", len(parts), parts)
+			}
+			if parts[0] != tc.role || parts[1] != tc.database || parts[2] != tc.parameter {
+				t.Fatalf("round-trip mismatch: got %q/%q/%q, want %q/%q/%q",
+					parts[0], parts[1], parts[2], tc.role, tc.database, tc.parameter)
+			}
+		})
+	}
+}
+
+// TestFindSetconfigValue exercises the pure parser against the formats
+// PostgreSQL actually produces in pg_db_role_setting.setconfig (verified
+// empirically on PG 16). It runs without a live database.
+func TestFindSetconfigValue(t *testing.T) {
+	cases := []struct {
+		name      string
+		setconfig []string
+		parameter string
+		want      string
+		wantFound bool
+	}{
+		{
+			name:      "unwrapped plain identifier",
+			setconfig: []string{"role=app_db_owner"},
+			parameter: "role",
+			want:      "app_db_owner",
+			wantFound: true,
+		},
+		{
+			name:      "wrapped value with comma and space",
+			setconfig: []string{`search_path="app, public"`},
+			parameter: "search_path",
+			want:      "app, public",
+			wantFound: true,
+		},
+		{
+			name:      "wrapped value with embedded double quote (doubled inside)",
+			setconfig: []string{`search_path="""a,b"", public"`},
+			parameter: "search_path",
+			want:      `"a,b", public`,
+			wantFound: true,
+		},
+		{
+			name: "multiple parameters, pick the requested one",
+			setconfig: []string{
+				`search_path="app, public"`,
+				"role=app_db_owner",
+			},
+			parameter: "role",
+			want:      "app_db_owner",
+			wantFound: true,
+		},
+		{
+			name:      "case-insensitive parameter match",
+			setconfig: []string{"role=app_db_owner"},
+			parameter: "ROLE",
+			want:      "app_db_owner",
+			wantFound: true,
+		},
+		{
+			name:      "parameter not present",
+			setconfig: []string{"role=app_db_owner"},
+			parameter: "search_path",
+			wantFound: false,
+		},
+		{
+			name:      "unwrapped value containing literal quote and comma (postgres leaves untouched)",
+			setconfig: []string{`application_name=has"quote,comma`},
+			parameter: "application_name",
+			want:      `has"quote,comma`,
+			wantFound: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, found := findSetconfigValue(tc.setconfig, tc.parameter)
+			if found != tc.wantFound {
+				t.Fatalf("found = %v, want %v", found, tc.wantFound)
+			}
+			if got != tc.want {
+				t.Fatalf("value = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAccPostgresqlRoleDatabaseSetting_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlRoleDatabaseSettingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPostgresqlRoleDatabaseSettingBasicConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlRoleDatabaseSettingValue(
+						"rds_test_owner@example.com", "rds_test_db", "role", "rds_test_owner",
+					),
+					resource.TestCheckResourceAttr(
+						"postgresql_role_database_setting.assume", "value", "rds_test_owner",
+					),
+					resource.TestCheckResourceAttr(
+						"postgresql_role_database_setting.assume", "id",
+						"rds_test_owner@example.com:rds_test_db:role",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlRoleDatabaseSetting_UpdateValue(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlRoleDatabaseSettingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPostgresqlRoleDatabaseSettingSearchPathConfig("public"),
+				Check: testAccCheckPostgresqlRoleDatabaseSettingValue(
+					"rds_test_owner@example.com", "rds_test_db", "search_path", "public",
+				),
+			},
+			{
+				Config: testAccPostgresqlRoleDatabaseSettingSearchPathConfig("app, public"),
+				Check: testAccCheckPostgresqlRoleDatabaseSettingValue(
+					"rds_test_owner@example.com", "rds_test_db", "search_path", "app, public",
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlRoleDatabaseSetting_MultipleParameters(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlRoleDatabaseSettingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPostgresqlRoleDatabaseSettingMultiConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlRoleDatabaseSettingValue(
+						"rds_test_owner@example.com", "rds_test_db", "role", "rds_test_owner",
+					),
+					testAccCheckPostgresqlRoleDatabaseSettingValue(
+						"rds_test_owner@example.com", "rds_test_db", "search_path", "shared, app, public",
+					),
+				),
+			},
+		},
+	})
+}
+
+// TestAccPostgresqlRoleDatabaseSetting_EmbeddedQuoteValue exercises the
+// catalog round-trip for a search_path value containing an embedded double
+// quote. PostgreSQL stores this in pg_db_role_setting using the wrapped form
+// with doubled inner quotes (`search_path="""a,b"", public"`). The Read path
+// must decode `""` → `"`, otherwise terraform plan reports a permanent
+// false-positive drift on every refresh.
+func TestAccPostgresqlRoleDatabaseSetting_EmbeddedQuoteValue(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlRoleDatabaseSettingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPostgresqlRoleDatabaseSettingSearchPathConfig(`"a,b", public`),
+				Check: testAccCheckPostgresqlRoleDatabaseSettingValue(
+					"rds_test_owner@example.com", "rds_test_db", "search_path", `"a,b", public`,
+				),
+			},
+			// A second step with the same config asserts no drift: if Read
+			// returned a mangled value, terraform would propose a re-apply
+			// here and the test would fail.
+			{
+				Config:   testAccPostgresqlRoleDatabaseSettingSearchPathConfig(`"a,b", public`),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccPostgresqlRoleDatabaseSetting_ColonInIdentifier verifies the
+// resource handles role/database names containing ':' end-to-end: apply,
+// state ID encoding, and import round-trip via ImportStateVerify.
+func TestAccPostgresqlRoleDatabaseSetting_ColonInIdentifier(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlRoleDatabaseSettingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPostgresqlRoleDatabaseSettingColonConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlRoleDatabaseSettingValue(
+						"alice:dev", "rds_app:blue_db", "role", "rds_test_owner",
+					),
+					resource.TestCheckResourceAttr(
+						"postgresql_role_database_setting.assume", "id",
+						`alice\:dev:rds_app\:blue_db:role`,
+					),
+				),
+			},
+			{
+				ResourceName:      "postgresql_role_database_setting.assume",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlRoleDatabaseSetting_Import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlRoleDatabaseSettingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPostgresqlRoleDatabaseSettingBasicConfig,
+			},
+			{
+				ResourceName:      "postgresql_role_database_setting.assume",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPostgresqlRoleDatabaseSettingValue(role, database, parameter, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*Client)
+		txn, err := startTransaction(client, "")
+		if err != nil {
+			return err
+		}
+		defer deferredRollback(txn)
+
+		var setconfig []string
+		err = txn.QueryRow(`
+SELECT s.setconfig
+FROM pg_db_role_setting s
+JOIN pg_roles r ON r.oid = s.setrole
+JOIN pg_database d ON d.oid = s.setdatabase
+WHERE r.rolname = $1 AND d.datname = $2`, role, database).Scan(pq.Array(&setconfig))
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("no pg_db_role_setting row for role %q in database %q", role, database)
+		}
+		if err != nil {
+			return fmt.Errorf("error reading pg_db_role_setting: %w", err)
+		}
+
+		got, found := findSetconfigValue(setconfig, parameter)
+		if !found {
+			return fmt.Errorf("parameter %q not found in setconfig %v for (%s, %s)", parameter, setconfig, role, database)
+		}
+		if got != expected {
+			return fmt.Errorf("parameter %q for (%s, %s) = %q, want %q", parameter, role, database, got, expected)
+		}
+		return nil
+	}
+}
+
+func testAccCheckPostgresqlRoleDatabaseSettingDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "postgresql_role_database_setting" {
+			continue
+		}
+
+		txn, err := startTransaction(client, "")
+		if err != nil {
+			return err
+		}
+		defer deferredRollback(txn)
+
+		parts := splitIDComponents(rs.Primary.ID)
+		if len(parts) != 3 {
+			return fmt.Errorf("malformed resource ID %q", rs.Primary.ID)
+		}
+		role, database, parameter := parts[0], parts[1], parts[2]
+
+		var setconfig []string
+		err = txn.QueryRow(`
+SELECT s.setconfig
+FROM pg_db_role_setting s
+JOIN pg_roles r ON r.oid = s.setrole
+JOIN pg_database d ON d.oid = s.setdatabase
+WHERE r.rolname = $1 AND d.datname = $2`, role, database).Scan(pq.Array(&setconfig))
+		switch {
+		case err == sql.ErrNoRows:
+			// Either the row was removed entirely (RESET of last param) or
+			// the role/database itself was dropped — either way the resource
+			// is gone.
+			continue
+		case err != nil:
+			return fmt.Errorf("error reading pg_db_role_setting: %w", err)
+		}
+
+		if _, found := findSetconfigValue(setconfig, parameter); found {
+			return fmt.Errorf(
+				"role-database setting %s for (%s, %s) still exists after destroy",
+				parameter, role, database,
+			)
+		}
+	}
+	return nil
+}
+
+const testAccPostgresqlRoleDatabaseSettingBasicConfig = `
+resource "postgresql_role" "owner" {
+  name  = "rds_test_owner"
+  login = false
+}
+
+resource "postgresql_role" "user" {
+  name    = "rds_test_owner@example.com"
+  login   = true
+  inherit = true
+  roles   = [postgresql_role.owner.name]
+}
+
+resource "postgresql_database" "db" {
+  name              = "rds_test_db"
+  owner             = postgresql_role.owner.name
+  allow_connections = true
+}
+
+resource "postgresql_role_database_setting" "assume" {
+  role      = postgresql_role.user.name
+  database  = postgresql_database.db.name
+  parameter = "role"
+  value     = postgresql_role.owner.name
+}
+`
+
+func testAccPostgresqlRoleDatabaseSettingSearchPathConfig(searchPath string) string {
+	return fmt.Sprintf(`
+resource "postgresql_role" "owner" {
+  name  = "rds_test_owner"
+  login = false
+}
+
+resource "postgresql_role" "user" {
+  name    = "rds_test_owner@example.com"
+  login   = true
+  inherit = true
+  roles   = [postgresql_role.owner.name]
+}
+
+resource "postgresql_database" "db" {
+  name              = "rds_test_db"
+  owner             = postgresql_role.owner.name
+  allow_connections = true
+}
+
+resource "postgresql_role_database_setting" "search_path" {
+  role      = postgresql_role.user.name
+  database  = postgresql_database.db.name
+  parameter = "search_path"
+  value     = %q
+}
+`, searchPath)
+}
+
+const testAccPostgresqlRoleDatabaseSettingColonConfig = `
+resource "postgresql_role" "owner" {
+  name  = "rds_test_owner"
+  login = false
+}
+
+resource "postgresql_role" "user" {
+  name    = "alice:dev"
+  login   = true
+  inherit = true
+  roles   = [postgresql_role.owner.name]
+}
+
+resource "postgresql_database" "db" {
+  name              = "rds_app:blue_db"
+  owner             = postgresql_role.owner.name
+  allow_connections = true
+}
+
+resource "postgresql_role_database_setting" "assume" {
+  role      = postgresql_role.user.name
+  database  = postgresql_database.db.name
+  parameter = "role"
+  value     = postgresql_role.owner.name
+}
+`
+
+const testAccPostgresqlRoleDatabaseSettingMultiConfig = `
+resource "postgresql_role" "owner" {
+  name  = "rds_test_owner"
+  login = false
+}
+
+resource "postgresql_role" "user" {
+  name    = "rds_test_owner@example.com"
+  login   = true
+  inherit = true
+  roles   = [postgresql_role.owner.name]
+}
+
+resource "postgresql_database" "db" {
+  name              = "rds_test_db"
+  owner             = postgresql_role.owner.name
+  allow_connections = true
+}
+
+resource "postgresql_role_database_setting" "assume" {
+  role      = postgresql_role.user.name
+  database  = postgresql_database.db.name
+  parameter = "role"
+  value     = postgresql_role.owner.name
+}
+
+resource "postgresql_role_database_setting" "search_path" {
+  role      = postgresql_role.user.name
+  database  = postgresql_database.db.name
+  parameter = "search_path"
+  value     = "shared, app, public"
+}
+`

--- a/website/docs/r/postgresql_role_database_setting.html.markdown
+++ b/website/docs/r/postgresql_role_database_setting.html.markdown
@@ -1,0 +1,114 @@
+---
+layout: "postgresql"
+page_title: "PostgreSQL: postgresql_role_database_setting"
+sidebar_current: "docs-postgresql-resource-postgresql_role_database_setting"
+description: |-
+  Manages a per-database role configuration parameter via ALTER ROLE ... IN DATABASE ... SET ...
+---
+
+# postgresql\_role\_database\_setting
+
+The ``postgresql_role_database_setting`` resource manages a single per-database role configuration parameter, i.e. a row in the system catalog [`pg_db_role_setting`](https://www.postgresql.org/docs/current/catalog-pg-db-role-setting.html). It corresponds to the SQL statement:
+
+```sql
+ALTER ROLE <role> IN DATABASE <database> SET <parameter> = '<value>';
+```
+
+Unlike the global `assume_role` attribute on `postgresql_role` (which translates to `ALTER ROLE … SET role = …` and applies cluster-wide), this resource scopes the setting to a specific database. Common use cases:
+
+- Auto-switching a developer role into a project-owned group role on connect: `parameter = "role"`, `value = "<project>_db_owner"`.
+- Setting a project-specific `search_path` for a shared role.
+- Tuning per-database `statement_timeout` for a service account.
+
+## Example: per-database `assume role` for an Entra ID developer
+
+```hcl
+resource "postgresql_role" "owner" {
+  name  = "app_db_owner"
+  login = false
+}
+
+resource "postgresql_role" "dev" {
+  name    = "alice@example.com"
+  login   = true
+  inherit = true
+  roles   = [postgresql_role.owner.name]
+}
+
+resource "postgresql_database" "db" {
+  name  = "app_db"
+  owner = postgresql_role.owner.name
+}
+
+resource "postgresql_role_database_setting" "dev_assume_owner" {
+  role      = postgresql_role.dev.name
+  database  = postgresql_database.db.name
+  parameter = "role"
+  value     = postgresql_role.owner.name
+}
+```
+
+When `alice@example.com` connects to `app_db`, their `current_role` is automatically set to `app_db_owner`, so any objects created by ad-hoc DDL or migrations are owned by the group role instead of the individual user.
+
+## Example: setting multiple parameters on the same (role, database) pair
+
+You can declare independent resources for each parameter; they coexist in the same `pg_db_role_setting` row without conflicting:
+
+```hcl
+resource "postgresql_role_database_setting" "search_path" {
+  role      = postgresql_role.dev.name
+  database  = postgresql_database.db.name
+  parameter = "search_path"
+  value     = "app, public"
+}
+
+resource "postgresql_role_database_setting" "statement_timeout" {
+  role      = postgresql_role.dev.name
+  database  = postgresql_database.db.name
+  parameter = "statement_timeout"
+  value     = "5min"
+}
+```
+
+Concurrent operations against the same `(role, database)` pair are serialized internally with a transactional advisory lock, so parallel `terraform apply` of multiple resources on the same pair is safe.
+
+## Caveat: per-DB `role` requires intact membership
+
+Per-database `role = <target>` only takes effect on connect if the connecting role is actually a member of `<target>`. The membership and the per-DB setting are stored in **different catalogs** (`pg_auth_members` vs `pg_db_role_setting`) and managed by different resources, so they can drift apart silently.
+
+The most common way they drift: `postgresql_role` manages memberships **authoritatively**. Its Update path REVOKEs every membership of the role found in `pg_auth_members`, then GRANTs only those listed in the resource's `roles = [...]`. Update fires when any attribute changes, or whenever Read sees memberships not in the config — the default state right after `terraform import`, unless the engineer manually copies all memberships into config.
+
+If the same role is also targeted by `postgresql_grant_role` rows from other modules (or by manual `GRANT` from a DBA), those memberships get silently revoked on the next `postgresql_role` apply. PostgreSQL then warns `permission denied to set role` on the role's next connect, and the session falls back to `current_role = <role>` — `pg_db_role_setting` is untouched but ineffective.
+
+The recommended patterns:
+
+- For **shared identities** (e.g. roles created externally and grant-wired into multiple projects): manage memberships exclusively via `postgresql_grant_role` (non-authoritative, scoped to one tuple), and do not declare the role as `postgresql_role`. Each project module then owns only its own grant + per-DB setting.
+- If `postgresql_role` must manage the role (e.g. for password / login attributes), add `lifecycle { ignore_changes = [roles, assume_role, search_path, statement_timeout] }` so it stops fighting the foreign grants.
+
+See [issue #285](https://github.com/cyrilgdn/terraform-provider-postgresql/issues/285) for the underlying `postgresql_role` behaviour.
+
+## Argument Reference
+
+* `role` - (Required) The role whose per-database setting is managed. Forces a new resource on change.
+* `database` - (Required) The database in which the setting applies. Forces a new resource on change.
+* `parameter` - (Required) The configuration parameter (any GUC name accepted by `ALTER ROLE`, e.g. `role`, `search_path`, `statement_timeout`). Forces a new resource on change.
+* `value` - (Required) The value to assign to the parameter for this `(role, database)` pair. The provider quotes the value as a string literal; PostgreSQL will interpret and canonicalize it according to the parameter's type.
+
+## Import
+
+Existing settings can be imported using the composite ID `<role>:<database>:<parameter>`:
+
+```shell
+terraform import postgresql_role_database_setting.dev_assume_owner \
+  'alice@example.com:app_db:role'
+```
+
+Names with `@`, `.`, or mixed case are supported as-is (the provider quotes identifiers correctly when emitting `ALTER ROLE`). PostgreSQL also allows literal `:` and `\` in quoted identifiers; in the import ID they must be backslash-escaped (`\:` and `\\`) so the three components remain unambiguous. The same encoding is what the resource emits for the state ID, so you can copy a state ID directly:
+
+```shell
+# role = "alice:dev", database = "app:blue", parameter = "role"
+terraform import postgresql_role_database_setting.dev_assume_owner \
+  'alice\:dev:app\:blue:role'
+```
+
+Use single quotes (or double-escape) when invoking `terraform import` from a shell, otherwise the shell will eat the backslashes.


### PR DESCRIPTION
Hi,

This PR adds a new `postgresql_role_database_setting` resource that wraps PostgreSQL's per-database role configuration: `ALTER ROLE <role> IN DATABASE <db> SET <param> = <value>` (and `RESET <param>` on destroy). It's the per-database counterpart to the cluster-wide `assume_role` / `search_path` / `statement_timeout` already exposed on `postgresql_role`.

The resource is generic across all GUCs — it operates directly on `pg_db_role_setting`, so a single resource shape covers `role`, `search_path`, `statement_timeout`, `work_mem`, etc., rather than adding a per-attribute `*_database` variant on `postgresql_role` for each one.

Example:

```hcl
resource "postgresql_role_database_setting" "dev_assume_owner" {
  role      = "alice@example.com"
  database  = "project_a_db"
  parameter = "role"
  value     = "project_a_db_owner"
}
```

`role`, `database`, `parameter` are `ForceNew`; `value` is mutable. Composite import ID: `<role>:<database>:<parameter>` with `:` / `\` backslash-escaped so identifiers containing them round-trip.

A few implementation notes:

- Identifiers go through `pq.QuoteIdentifier`, values through `pq.QuoteLiteral`. Names with `@` / `.` / mixed case (e.g. UPN-style logins) work as-is.
- `RESET <param>` only clears the targeted parameter, so multiple resources for the same `(role, database)` pair (e.g. one for `role`, one for `search_path`) coexist without trampling each other.
- Create takes a transactional advisory lock on `hash(role) ^ hash(database)` to serialize concurrent writes against the same pair, since `pg_db_role_setting.setconfig` is a single `text[]` and parallel `ALTER ROLE` rewrites can otherwise drop each other's entries.
- Read parses `setconfig`; missing rows clear the ID so out-of-band `RESET` is surfaced as a plan.

Acceptance tests cover CRUD, update, multi-parameter coexistence on the same `(role, database)`, import, drift detection after out-of-band `RESET`, and special-character role names. Docs added at `website/docs/r/postgresql_role_database_setting.html.markdown`.

Closes #609 and #526. Context and a fork-usage fallback are in #634.

Happy to adjust naming or shape if a different fit with the existing schema is preferred.
