### PR TITLE
feat(role): add client_connection_check_interval and generic parameters map

### DIFF
--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -23,6 +24,7 @@ const (
 	roleCreateRoleAttr                      = "create_role"
 	roleEncryptedPassAttr                   = "encrypted_password"
 	roleIdleInTransactionSessionTimeoutAttr = "idle_in_transaction_session_timeout"
+	roleClientConnectionCheckIntervalAttr   = "client_connection_check_interval"
 	roleInheritAttr                         = "inherit"
 	roleLoginAttr                           = "login"
 	roleNameAttr                            = "name"
@@ -38,10 +40,26 @@ const (
 	roleSearchPathAttr                      = "search_path"
 	roleStatementTimeoutAttr                = "statement_timeout"
 	roleAssumeRoleAttr                      = "assume_role"
+	roleParametersAttr                      = "parameters"
 
 	// Deprecated options
 	roleDepEncryptedAttr = "encrypted"
 )
+
+// roleReservedParameters are GUCs already managed by dedicated typed attributes;
+// they must not be set through the generic `parameters` map to avoid two
+// attributes fighting over the same rolconfig entry.
+var roleReservedParameters = map[string]bool{
+	roleSearchPathAttr:                      true,
+	roleStatementTimeoutAttr:                true,
+	roleIdleInTransactionSessionTimeoutAttr: true,
+	roleClientConnectionCheckIntervalAttr:   true,
+}
+
+// validRoleParameterName guards against SQL injection via GUC names, which are
+// interpolated unquoted into ALTER ROLE ... SET. Allows an optional single
+// namespace prefix (e.g. `pgaudit.log`).
+var validRoleParameterName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$`)
 
 func resourcePostgreSQLRole() *schema.Resource {
 	return &schema.Resource{
@@ -146,6 +164,12 @@ func resourcePostgreSQLRole() *schema.Resource {
 				Description:  "Terminate any session with an open transaction that has been idle for longer than the specified duration in milliseconds",
 				ValidateFunc: validation.IntAtLeast(0),
 			},
+			roleClientConnectionCheckIntervalAttr: {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Description:  "Sets the time interval in milliseconds between checks that the client is still connected while running queries; 0 disables the checks",
+				ValidateFunc: validation.IntAtLeast(0),
+			},
 			roleInheritAttr: {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -192,6 +216,12 @@ func resourcePostgreSQLRole() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Role to switch to at login",
+			},
+			roleParametersAttr: {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Arbitrary per-role configuration parameters (ALTER ROLE ... SET key TO value). Keys managed by dedicated attributes (search_path, statement_timeout, idle_in_transaction_session_timeout, client_connection_check_interval) are not allowed here.",
 			},
 		},
 	}
@@ -366,7 +396,15 @@ func resourcePostgreSQLRoleCreate(db *DBConnection, d *schema.ResourceData) erro
 		return err
 	}
 
+	if err = setClientConnectionCheckInterval(txn, d); err != nil {
+		return err
+	}
+
 	if err = setAssumeRole(txn, d); err != nil {
+		return err
+	}
+
+	if err = setRoleParameters(txn, d); err != nil {
 		return err
 	}
 
@@ -531,6 +569,15 @@ func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) er
 
 	d.Set(roleIdleInTransactionSessionTimeoutAttr, idleInTransactionSessionTimeout)
 
+	clientConnectionCheckInterval, err := readClientConnectionCheckInterval(roleConfig)
+	if err != nil {
+		return err
+	}
+
+	d.Set(roleClientConnectionCheckIntervalAttr, clientConnectionCheckInterval)
+
+	d.Set(roleParametersAttr, readRoleParameters(roleConfig))
+
 	d.SetId(roleName)
 
 	if _, ok := d.GetOk(rolePasswordAttr); ok {
@@ -569,6 +616,42 @@ func readIdleInTransactionSessionTimeout(roleConfig pq.ByteaArray) (int, error) 
 			res, err := strconv.Atoi(result[0])
 			if err != nil {
 				return -1, fmt.Errorf("error reading statement_timeout: %w", err)
+			}
+			return res, nil
+		}
+	}
+	return 0, nil
+}
+
+// readRoleParameters parses the rolconfig array into a map of GUC name -> value,
+// skipping keys that are managed by dedicated typed attributes.
+func readRoleParameters(roleConfig pq.ByteaArray) map[string]string {
+	params := make(map[string]string)
+	for _, v := range roleConfig {
+		config := string(v)
+		parts := strings.SplitN(config, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := parts[0]
+		if roleReservedParameters[key] {
+			continue
+		}
+		params[key] = parts[1]
+	}
+	return params
+}
+
+// readClientConnectionCheckInterval searches for a client_connection_check_interval entry in the rolconfig array.
+// In case no such value is present, it returns 0.
+func readClientConnectionCheckInterval(roleConfig pq.ByteaArray) (int, error) {
+	for _, v := range roleConfig {
+		config := string(v)
+		if strings.HasPrefix(config, roleClientConnectionCheckIntervalAttr) {
+			var result = strings.Split(strings.TrimPrefix(config, roleClientConnectionCheckIntervalAttr+"="), ", ")
+			res, err := strconv.Atoi(result[0])
+			if err != nil {
+				return -1, fmt.Errorf("error reading client_connection_check_interval: %w", err)
 			}
 			return res, nil
 		}
@@ -745,7 +828,15 @@ func resourcePostgreSQLRoleUpdate(db *DBConnection, d *schema.ResourceData) erro
 		return err
 	}
 
+	if err = setClientConnectionCheckInterval(txn, d); err != nil {
+		return err
+	}
+
 	if err = setAssumeRole(txn, d); err != nil {
+		return err
+	}
+
+	if err = setRoleParameters(txn, d); err != nil {
 		return err
 	}
 
@@ -1114,6 +1205,73 @@ func setIdleInTransactionSessionTimeout(txn *sql.Tx, d *schema.ResourceData) err
 		)
 		if _, err := txn.Exec(sql); err != nil {
 			return fmt.Errorf("could not reset idle_in_transaction_session_timeout for %s: %w", roleName, err)
+		}
+	}
+	return nil
+}
+
+func setClientConnectionCheckInterval(txn *sql.Tx, d *schema.ResourceData) error {
+	if !d.HasChange(roleClientConnectionCheckIntervalAttr) {
+		return nil
+	}
+
+	roleName := d.Get(roleNameAttr).(string)
+	clientConnectionCheckInterval := d.Get(roleClientConnectionCheckIntervalAttr).(int)
+	if clientConnectionCheckInterval != 0 {
+		sql := fmt.Sprintf(
+			"ALTER ROLE %s SET client_connection_check_interval TO %d", pq.QuoteIdentifier(roleName), clientConnectionCheckInterval,
+		)
+		if _, err := txn.Exec(sql); err != nil {
+			return fmt.Errorf("could not set client_connection_check_interval %d for %s: %w", clientConnectionCheckInterval, roleName, err)
+		}
+	} else {
+		sql := fmt.Sprintf(
+			"ALTER ROLE %s RESET client_connection_check_interval", pq.QuoteIdentifier(roleName),
+		)
+		if _, err := txn.Exec(sql); err != nil {
+			return fmt.Errorf("could not reset client_connection_check_interval for %s: %w", roleName, err)
+		}
+	}
+	return nil
+}
+
+func setRoleParameters(txn *sql.Tx, d *schema.ResourceData) error {
+	if !d.HasChange(roleParametersAttr) {
+		return nil
+	}
+
+	roleName := d.Get(roleNameAttr).(string)
+	oldRaw, newRaw := d.GetChange(roleParametersAttr)
+	oldParams := oldRaw.(map[string]any)
+	newParams := newRaw.(map[string]any)
+
+	// RESET parameters that were removed from the map.
+	for key := range oldParams {
+		if _, ok := newParams[key]; ok {
+			continue
+		}
+		if !validRoleParameterName.MatchString(key) {
+			return fmt.Errorf("invalid parameter name %q for %s", key, roleName)
+		}
+		sql := fmt.Sprintf("ALTER ROLE %s RESET %s", pq.QuoteIdentifier(roleName), key)
+		if _, err := txn.Exec(sql); err != nil {
+			return fmt.Errorf("could not reset parameter %s for %s: %w", key, roleName, err)
+		}
+	}
+
+	// SET (or update) every parameter currently in the map.
+	for key, v := range newParams {
+		if roleReservedParameters[key] {
+			return fmt.Errorf("parameter %q is managed by a dedicated attribute and cannot be set via %s", key, roleParametersAttr)
+		}
+		if !validRoleParameterName.MatchString(key) {
+			return fmt.Errorf("invalid parameter name %q for %s", key, roleName)
+		}
+		sql := fmt.Sprintf(
+			"ALTER ROLE %s SET %s TO '%s'", pq.QuoteIdentifier(roleName), key, pqQuoteLiteral(v.(string)),
+		)
+		if _, err := txn.Exec(sql); err != nil {
+			return fmt.Errorf("could not set parameter %s for %s: %w", key, roleName, err)
 		}
 	}
 	return nil

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -47,6 +47,8 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_reassign_owned", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "idle_in_transaction_session_timeout", "0"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "client_connection_check_interval", "0"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "parameters.%", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "assume_role", ""),
 
 					resource.TestCheckResourceAttr("postgresql_role.role_with_create_database", "name", "role_with_create_database"),
@@ -122,6 +124,10 @@ resource "postgresql_role" "update_role" {
   search_path = ["mysearchpath"]
   statement_timeout = 30000
   idle_in_transaction_session_timeout = 60000
+  client_connection_check_interval = 15000
+  parameters = {
+    lock_timeout = "5000"
+  }
   assume_role = "${postgresql_role.group_role.name}"
 }
 `
@@ -146,6 +152,8 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "search_path.#", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "client_connection_check_interval", "0"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "parameters.%", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
@@ -167,6 +175,9 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "search_path.0", "mysearchpath"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "30000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "60000"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "client_connection_check_interval", "15000"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "parameters.%", "1"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "parameters.lock_timeout", "5000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", "group_role"),
 					testAccCheckRoleCanLogin(t, "update_role2", "titi"),
 				),
@@ -185,6 +196,8 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "search_path.#", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "client_connection_check_interval", "0"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "parameters.%", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -168,6 +168,12 @@ resource "postgresql_role" "app_user" {
 
 * `statement_timeout` - (Optional) Defines [`statement_timeout`](https://www.postgresql.org/docs/current/runtime-config-client.html#RUNTIME-CONFIG-CLIENT-STATEMENT) setting for this role which allows to abort any statement that takes more than the specified amount of time.
 
+* `idle_in_transaction_session_timeout` - (Optional) Defines [`idle_in_transaction_session_timeout`](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT) setting for this role which terminates any session with an open transaction idle for longer than the specified number of milliseconds.
+
+* `client_connection_check_interval` - (Optional) Defines [`client_connection_check_interval`](https://www.postgresql.org/docs/current/runtime-config-connection.html#GUC-CLIENT-CONNECTION-CHECK-INTERVAL) setting for this role which sets the interval in milliseconds between checks that the client is still connected while running a query; `0` (default) disables the checks.
+
+* `parameters` - (Optional) A map of arbitrary per-role configuration parameters applied via [`ALTER ROLE ... SET`](https://www.postgresql.org/docs/current/sql-alterrole.html) (e.g. `lock_timeout`, `work_mem`, `default_transaction_isolation`). Removing a key resets it to the cluster default. Namespaced GUCs such as `pgaudit.log` are allowed. Keys managed by a dedicated attribute (`search_path`, `statement_timeout`, `idle_in_transaction_session_timeout`, `client_connection_check_interval`) are rejected here. The value must match the form PostgreSQL stores in `pg_roles.rolconfig`, otherwise the plan may show perpetual drift.
+
 * `assume_role` - (Optional) Defines the role to switch to at login via [`SET ROLE`](https://www.postgresql.org/docs/current/sql-set-role.html).
 
 ## Import Example


### PR DESCRIPTION
## Summary

Extends `postgresql_role` with two ways to manage per-role configuration (`ALTER ROLE ... SET`):

- **`client_connection_check_interval`** — typed int (milliseconds), `0` disables the check. Mirrors the existing `statement_timeout` / `idle_in_transaction_session_timeout` handling.
- **`parameters`** — a generic map of arbitrary GUCs (e.g. `lock_timeout`, `work_mem`, `pgaudit.log`), so future role-level settings no longer each need a dedicated attribute. Removing a key `RESET`s it to the cluster default.

```hcl
resource "postgresql_role" "app" {
  name                             = "app"
  client_connection_check_interval = 30000
  parameters = {
    lock_timeout  = "5000"
    work_mem      = "32MB"
    "pgaudit.log" = "ddl"
  }
}
```

## Notes

- The `parameters` map **rejects** keys already managed by typed attributes (`search_path`, `statement_timeout`, `idle_in_transaction_session_timeout`, `client_connection_check_interval`) to prevent two attributes fighting over the same `rolconfig` entry. On read, those keys are filtered out of the map so there is no spurious drift.
- GUC names in `parameters` are validated against a strict regex (optional single namespace prefix, e.g. `pgaudit.log`) since they are interpolated unquoted into the `SET` statement. Values go through the existing `pqQuoteLiteral`.
- Also documents the previously undocumented `idle_in_transaction_session_timeout` attribute.

## Tests

Extends the existing `postgresql_role` acceptance test to cover both new attributes (create / update / reset). `go build`, `go vet`, and `gofmt` are clean. Acceptance tests require `TF_ACC=1` against a live PostgreSQL and were not run locally.