### PR TITLE
feat: add publish_generated_columns support to postgresql_publication

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -47,6 +47,7 @@ const (
 	featureCreateRoleSelfGrant
 	featureSecurityLabel
 	featureMaintainPrivilege
+	featurePubGeneratedColumns
 )
 
 var (
@@ -126,6 +127,9 @@ var (
 
 		// MAINTAIN privilege on tables (PG 17+)
 		featureMaintainPrivilege: semver.MustParseRange(">=17.0.0"),
+
+		// publish_generated_columns for publications (PG 18+)
+		featurePubGeneratedColumns: semver.MustParseRange(">=18.0.0"),
 	}
 )
 

--- a/postgresql/resource_postgresql_publication.go
+++ b/postgresql/resource_postgresql_publication.go
@@ -20,6 +20,7 @@ const (
 	pubDropCascadeAttr             = "drop_cascade"
 	pubPublishAttr                 = "publish_param"
 	pubPublishViaPartitionRootAttr = "publish_via_partition_root_param"
+	pubPublishGeneratedColumnsAttr = "publish_generated_columns_param"
 )
 
 func resourcePostgreSQLPublication() *schema.Resource {
@@ -85,6 +86,14 @@ func resourcePostgreSQLPublication() *schema.Resource {
 				ForceNew:    false,
 				Description: "Sets whether changes in a partitioned table using the identity and schema of the partitioned table",
 			},
+			pubPublishGeneratedColumnsAttr: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     false,
+				ValidateFunc: validation.StringInSlice([]string{"none", "stored"}, false),
+				Description:  "Sets whether generated columns are replicated ('none' or 'stored')",
+			},
 			pubDropCascadeAttr: {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -119,7 +128,7 @@ func resourcePostgreSQLPublicationUpdate(db *DBConnection, d *schema.ResourceDat
 		return fmt.Errorf("could not update publication tables: %w", err)
 	}
 
-	if err := setPubParams(txn, d, db.featureSupported(featurePublishViaRoot)); err != nil {
+	if err := setPubParams(txn, d, db.featureSupported(featurePublishViaRoot), db.featureSupported(featurePubGeneratedColumns)); err != nil {
 		return fmt.Errorf("could not update publication tables: %w", err)
 	}
 
@@ -200,10 +209,10 @@ func setPubTables(txn *sql.Tx, d *schema.ResourceData) error {
 	return nil
 }
 
-func setPubParams(txn *sql.Tx, d *schema.ResourceData, pubViaRootEnabled bool) error {
+func setPubParams(txn *sql.Tx, d *schema.ResourceData, pubViaRootEnabled bool, pubGenColsEnabled bool) error {
 	pubName := d.Get(pubNameAttr).(string)
 	paramAlterTemplate := "ALTER PUBLICATION %s %s"
-	publicationParametersString, err := getPublicationParameters(d, pubViaRootEnabled)
+	publicationParametersString, err := getPublicationParameters(d, pubViaRootEnabled, pubGenColsEnabled)
 	if err != nil {
 		return fmt.Errorf("error getting publication parameters: %w", err)
 	}
@@ -230,7 +239,7 @@ func resourcePostgreSQLPublicationCreate(db *DBConnection, d *schema.ResourceDat
 	if err != nil {
 		return fmt.Errorf("could not get tables for publication: %w", err)
 	}
-	publicationParameters, err := getPublicationParameters(d, db.featureSupported(featurePublishViaRoot))
+	publicationParameters, err := getPublicationParameters(d, db.featureSupported(featurePublishViaRoot), db.featureSupported(featurePubGeneratedColumns))
 	if err != nil {
 		return fmt.Errorf("could not get publication parameters: %w", err)
 	}
@@ -323,7 +332,7 @@ func resourcePostgreSQLPublicationReadImpl(db *DBConnection, d *schema.ResourceD
 	var tables []string
 	var publishParams []string
 	var puballtables, pubinsert, pubupdate, pubdelete, pubtruncate, pubviaroot bool
-	var pubowner string
+	var pubowner, pubgencols string
 	columns := []string{"puballtables", "pubinsert", "pubupdate", "pubdelete", "r.rolname as pubownername"}
 	values := []any{
 		&puballtables,
@@ -340,6 +349,10 @@ func resourcePostgreSQLPublicationReadImpl(db *DBConnection, d *schema.ResourceD
 	if db.featureSupported(featurePubTruncate) {
 		columns = append(columns, "pubtruncate")
 		values = append(values, &pubtruncate)
+	}
+	if db.featureSupported(featurePubGeneratedColumns) {
+		columns = append(columns, "pubgencols")
+		values = append(values, &pubgencols)
 	}
 
 	query := fmt.Sprintf("SELECT %s FROM pg_catalog.pg_publication as p join pg_catalog.pg_roles as r on p.pubowner = r.oid WHERE pubname = $1", strings.Join(columns, ", "))
@@ -402,6 +415,13 @@ func resourcePostgreSQLPublicationReadImpl(db *DBConnection, d *schema.ResourceD
 	d.Set(pubPublishAttr, publishParams)
 	if sliceContainsStr(columns, "pubviaroot") {
 		d.Set(pubPublishViaPartitionRootAttr, pubviaroot)
+	}
+	if sliceContainsStr(columns, "pubgencols") {
+		genCols := "none"
+		if pubgencols == "s" {
+			genCols = "stored"
+		}
+		d.Set(pubPublishGeneratedColumnsAttr, genCols)
 	}
 	return nil
 }
@@ -490,10 +510,10 @@ func validatedPublicationPublishParams(paramList []any) ([]string, error) {
 	return attrs, nil
 }
 
-func getPublicationParameters(d *schema.ResourceData, pubViaRootEnabled bool) (string, error) {
+func getPublicationParameters(d *schema.ResourceData, pubViaRootEnabled bool, pubGenColsEnabled bool) (string, error) {
 	parameterSQLTemplate := ""
 	returnValue := ""
-	pubParams := make(map[string]string, 2)
+	pubParams := make(map[string]string, 3)
 	if d.IsNewResource() {
 		if v, ok := d.GetOk(pubPublishViaPartitionRootAttr); ok {
 			if !pubViaRootEnabled {
@@ -502,6 +522,15 @@ func getPublicationParameters(d *schema.ResourceData, pubViaRootEnabled bool) (s
 				)
 			}
 			pubParams["publish_via_partition_root"] = fmt.Sprintf("%v", v.(bool))
+		}
+
+		if v, ok := d.GetOk(pubPublishGeneratedColumnsAttr); ok {
+			if !pubGenColsEnabled {
+				return "", fmt.Errorf(
+					"%s attribute is supported only for postgres version 18 and above", pubPublishGeneratedColumnsAttr,
+				)
+			}
+			pubParams["publish_generated_columns"] = fmt.Sprintf("'%s'", v.(string))
 		}
 
 		if v, ok := d.GetOk(pubPublishAttr); ok {
@@ -524,6 +553,16 @@ func getPublicationParameters(d *schema.ResourceData, pubViaRootEnabled bool) (s
 			}
 			_, nraw := d.GetChange(pubPublishViaPartitionRootAttr)
 			pubParams["publish_via_partition_root"] = fmt.Sprintf("%v", nraw.(bool))
+		}
+
+		if d.HasChange(pubPublishGeneratedColumnsAttr) {
+			if !pubGenColsEnabled {
+				return "", fmt.Errorf(
+					"%s attribute is supported only for postgres version 18 and above", pubPublishGeneratedColumnsAttr,
+				)
+			}
+			_, nraw := d.GetChange(pubPublishGeneratedColumnsAttr)
+			pubParams["publish_generated_columns"] = fmt.Sprintf("'%s'", nraw.(string))
 		}
 
 		if d.HasChange(pubPublishAttr) {

--- a/postgresql/resource_postgresql_publication_test.go
+++ b/postgresql/resource_postgresql_publication_test.go
@@ -817,3 +817,64 @@ resource "postgresql_publication" "test" {
 		},
 	})
 }
+
+func TestAccPostgresqlPublication_GeneratedColumns(t *testing.T) {
+	skipIfNotAcc(t)
+
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+	testTables := []string{"test_schema.test_table_1", "test_schema.test_table_2"}
+	createTestTables(t, dbSuffix, testTables, "")
+
+	dbName, _ := getTestDBNames(dbSuffix)
+
+	testAccPostgresqlPublicationStoredConfig := fmt.Sprintf(`
+	resource "postgresql_publication" "test" {
+		name                            = "publication"
+		database                        = "%s"
+		publish_generated_columns_param = "stored"
+	}
+	`, dbName)
+
+	testAccPostgresqlPublicationNoneConfig := fmt.Sprintf(`
+	resource "postgresql_publication" "test" {
+		name                            = "publication"
+		database                        = "%s"
+		publish_generated_columns_param = "none"
+	}
+	`, dbName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featurePublication)
+			testCheckCompatibleVersion(t, featurePubGeneratedColumns)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlPublicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccPostgresqlPublicationStoredConfig,
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlPublicationExists("postgresql_publication.test"),
+					resource.TestCheckResourceAttr(
+						"postgresql_publication.test", "name", "publication"),
+					resource.TestCheckResourceAttr(
+						"postgresql_publication.test", pubDatabaseAttr, dbName),
+					resource.TestCheckResourceAttr(
+						"postgresql_publication.test", pubPublishGeneratedColumnsAttr, "stored"),
+				),
+			},
+			{
+				Config: testAccPostgresqlPublicationNoneConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlPublicationExists("postgresql_publication.test"),
+					resource.TestCheckResourceAttr(
+						"postgresql_publication.test", pubPublishGeneratedColumnsAttr, "none"),
+				),
+			},
+		},
+	})
+}

--- a/website/docs/r/postgresql_publication.markdown
+++ b/website/docs/r/postgresql_publication.markdown
@@ -30,6 +30,7 @@ resource "postgresql_publication" "publication" {
 - `drop_cascade` - (Optional) Should all subsequent resources of the publication be dropped. Defaults to 'false'
 - `publish_param` - (Optional) Which 'publish' options should be turned on. Default to 'insert','update','delete'
 - `publish_via_partition_root_param` - (Optional) Should be option 'publish_via_partition_root' be turned on. Default to 'false'
+- `publish_generated_columns_param` - (Optional) Whether generated columns are replicated: `none` or `stored`. Requires PostgreSQL 18+. Defaults to `none`.
 
 ## Import Example
 


### PR DESCRIPTION
## Summary

Adds support for managing the PostgreSQL 18 publication option `publish_generated_columns` on the `postgresql_publication` resource, via a new `publish_generated_columns_param` attribute.

Fixes #611

## Details

- **`publish_generated_columns`** is a PostgreSQL 18 publication option (enum `none`/`stored`, default `none`) controlling whether stored generated columns are replicated:
  ```sql
  ALTER PUBLICATION <name> SET (publish_generated_columns = none|stored);
  ```
- New attribute `publish_generated_columns_param` (string, `none`/`stored`), `Optional + Computed` with `StringInSlice` validation so the catalog default (`none`) doesn't produce a perpetual diff when omitted.
- Version-gated to PG 18+ via a new `featurePubGeneratedColumns` feature flag (`>=18.0.0`), following the existing `featurePublishViaRoot`/`featurePubTruncate` pattern. Using the attribute against PG <18 returns a clear error.
- Wired through CREATE (`WITH (...)`) and ALTER (`SET (...)`) in `getPublicationParameters`, and read back from `pg_publication.pubgencols` (`s` → `stored`, otherwise `none`).
- Documentation updated.

## Testing

Acceptance tests run against PostgreSQL 18.4:

- New `TestAccPostgresqlPublication_GeneratedColumns` — creates with `stored`, updates to `none`, asserts read-back. **PASS**
- Full `TestAccPostgresqlPublication_*` suite — no regressions. **PASS** (pre-PG11 truncate tests skip as expected on PG 18)
- `go build`, `go vet`, `gofmt` clean.

The new test is gated with `testCheckCompatibleVersion(t, featurePubGeneratedColumns)` so it skips cleanly on PG <18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)