### PR TITLE
Remove redundant Exists callbacks, fix physical replication slot drift

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -3,6 +3,7 @@ package postgresql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -11,7 +12,7 @@ import (
 	"unicode"
 
 	"github.com/blang/semver"
-	_ "github.com/lib/pq" // PostgreSQL db
+	"github.com/lib/pq"
 	"gocloud.dev/gcp"
 	"gocloud.dev/gcp/cloudsql"
 	"gocloud.dev/postgres"
@@ -305,6 +306,14 @@ func (c *Client) Connect() (*DBConnection, error) {
 			err = db.Ping()
 		}
 		if err != nil {
+			// Server-side errors (e.g. a dropped database, SQLSTATE 3D000) never
+			// contain the password, so wrap them to preserve the *pq.Error type
+			// for callers such as isDatabaseDoesNotExistError. Other errors (dial
+			// failures, DSN parsing) may echo the password, so keep redacting.
+			var pqErr *pq.Error
+			if errors.As(err, &pqErr) {
+				return nil, fmt.Errorf("error connecting to PostgreSQL server %s (scheme: %s): %w", c.config.Host, c.config.Scheme, err)
+			}
 			errString := strings.Replace(err.Error(), c.config.Password, "XXXX", 2)
 			return nil, fmt.Errorf("error connecting to PostgreSQL server %s (scheme: %s): %s", c.config.Host, c.config.Scheme, errString)
 		}

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -24,19 +24,6 @@ func PGResourceFunc(fn func(*DBConnection, *schema.ResourceData) error) func(*sc
 	}
 }
 
-func PGResourceExistsFunc(fn func(*DBConnection, *schema.ResourceData) (bool, error)) func(*schema.ResourceData, any) (bool, error) {
-	return func(d *schema.ResourceData, meta any) (bool, error) {
-		client := meta.(*Client)
-
-		db, err := client.Connect()
-		if err != nil {
-			return false, err
-		}
-
-		return fn(db, d)
-	}
-}
-
 // QueryAble is a DB connection (sql.DB/Tx)
 type QueryAble interface {
 	Exec(query string, args ...any) (sql.Result, error)

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -23,7 +23,7 @@ import (
 func isDatabaseDoesNotExistError(err error) bool {
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) {
-		return pqErr.Code.Name() == "invalid_catalog_name"
+		return pqErr.Code == "3D000" // invalid_catalog_name
 	}
 	return false
 }

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -2,6 +2,7 @@ package postgresql
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -10,6 +11,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/lib/pq"
 )
+
+// isDatabaseDoesNotExistError reports whether err was caused by connecting to or
+// querying a PostgreSQL database that no longer exists (SQLSTATE 3D000,
+// invalid_catalog_name). Read functions use it to prune resources whose database
+// was dropped out-of-band instead of failing the whole refresh.
+//
+// It only matches when the driver exposes a *pq.Error; for any other error (or a
+// driver that does not, such as some gocloud schemes) it returns false, so the
+// caller keeps its existing error handling.
+func isDatabaseDoesNotExistError(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code.Name() == "invalid_catalog_name"
+	}
+	return false
+}
 
 func PGResourceFunc(fn func(*DBConnection, *schema.ResourceData) error) func(*schema.ResourceData, any) error {
 	return func(d *schema.ResourceData, meta any) error {

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -33,7 +33,6 @@ func resourcePostgreSQLDatabase() *schema.Resource {
 		Read:   PGResourceFunc(resourcePostgreSQLDatabaseRead),
 		Update: PGResourceFunc(resourcePostgreSQLDatabaseUpdate),
 		Delete: PGResourceFunc(resourcePostgreSQLDatabaseDelete),
-		Exists: PGResourceExistsFunc(resourcePostgreSQLDatabaseExists),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -296,16 +295,6 @@ func resourcePostgreSQLDatabaseDelete(db *DBConnection, d *schema.ResourceData) 
 
 	// Returning err even if it's nil so defer func can modify it.
 	return err
-}
-
-func resourcePostgreSQLDatabaseExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
-	txn, err := startTransaction(db.client, "")
-	if err != nil {
-		return false, err
-	}
-	defer deferredRollback(txn)
-
-	return dbExists(txn, d.Id())
 }
 
 func resourcePostgreSQLDatabaseRead(db *DBConnection, d *schema.ResourceData) error {

--- a/postgresql/resource_postgresql_extension.go
+++ b/postgresql/resource_postgresql_extension.go
@@ -27,7 +27,6 @@ func resourcePostgreSQLExtension() *schema.Resource {
 		Read:   PGResourceFunc(resourcePostgreSQLExtensionRead),
 		Update: PGResourceFunc(resourcePostgreSQLExtensionUpdate),
 		Delete: PGResourceFunc(resourcePostgreSQLExtensionDelete),
-		Exists: PGResourceExistsFunc(resourcePostgreSQLExtensionExists),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -117,45 +116,6 @@ func resourcePostgreSQLExtensionCreate(db *DBConnection, d *schema.ResourceData)
 	d.SetId(generateExtensionID(d, databaseName))
 
 	return resourcePostgreSQLExtensionReadImpl(db, d)
-}
-
-func resourcePostgreSQLExtensionExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
-	if !db.featureSupported(featureExtension) {
-		return false, fmt.Errorf(
-			"postgresql_extension resource is not supported for this Postgres version (%s)",
-			db.version,
-		)
-	}
-
-	var extensionName string
-
-	database, extName, err := getDBExtName(d, db.client)
-	if err != nil {
-		return false, err
-	}
-
-	// Check if the database exists
-	exists, err := dbExists(db, database)
-	if err != nil || !exists {
-		return false, err
-	}
-
-	txn, err := startTransaction(db.client, database)
-	if err != nil {
-		return false, err
-	}
-	defer deferredRollback(txn)
-
-	query := "SELECT extname FROM pg_catalog.pg_extension WHERE extname = $1"
-	err = txn.QueryRow(query, extName).Scan(&extensionName)
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
-		return false, err
-	}
-
-	return true, nil
 }
 
 func resourcePostgreSQLExtensionRead(db *DBConnection, d *schema.ResourceData) error {

--- a/postgresql/resource_postgresql_extension.go
+++ b/postgresql/resource_postgresql_extension.go
@@ -137,6 +137,11 @@ func resourcePostgreSQLExtensionReadImpl(db *DBConnection, d *schema.ResourceDat
 
 	txn, err := startTransaction(db.client, database)
 	if err != nil {
+		if isDatabaseDoesNotExistError(err) {
+			log.Printf("[WARN] PostgreSQL database (%s) not found, removing extension (%s) from state", database, extName)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	defer deferredRollback(txn)

--- a/postgresql/resource_postgresql_function.go
+++ b/postgresql/resource_postgresql_function.go
@@ -41,7 +41,6 @@ func resourcePostgreSQLFunction() *schema.Resource {
 		Read:   PGResourceFunc(resourcePostgreSQLFunctionRead),
 		Update: PGResourceFunc(resourcePostgreSQLFunctionUpdate),
 		Delete: PGResourceFunc(resourcePostgreSQLFunctionDelete),
-		Exists: PGResourceExistsFunc(resourcePostgreSQLFunctionExists),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -193,42 +192,6 @@ func resourcePostgreSQLFunctionCreate(db *DBConnection, d *schema.ResourceData) 
 	}
 
 	return resourcePostgreSQLFunctionReadImpl(db, d)
-}
-
-func resourcePostgreSQLFunctionExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
-	if !db.featureSupported(featureFunction) {
-		return false, fmt.Errorf(
-			"postgresql_function resource is not supported for this Postgres version (%s)",
-			db.version,
-		)
-	}
-
-	functionId := d.Id()
-
-	databaseName, functionSignature, expandErr := expandFunctionID(functionId, d, db)
-	if expandErr != nil {
-		return false, expandErr
-	}
-
-	var functionExists bool
-
-	txn, err := startTransaction(db.client, databaseName)
-	if err != nil {
-		return false, err
-	}
-	defer deferredRollback(txn)
-
-	query := fmt.Sprintf("SELECT to_regprocedure('%s') IS NOT NULL AS functionExists", functionSignature)
-
-	if err := txn.QueryRow(query).Scan(&functionExists); err != nil {
-		return false, err
-	}
-
-	if err := txn.Commit(); err != nil {
-		return false, err
-	}
-
-	return functionExists, nil
 }
 
 func resourcePostgreSQLFunctionRead(db *DBConnection, d *schema.ResourceData) error {

--- a/postgresql/resource_postgresql_function.go
+++ b/postgresql/resource_postgresql_function.go
@@ -231,6 +231,11 @@ func resourcePostgreSQLFunctionReadImpl(db *DBConnection, d *schema.ResourceData
 
 	txn, err := startTransaction(db.client, databaseName)
 	if err != nil {
+		if isDatabaseDoesNotExistError(err) {
+			log.Printf("[WARN] PostgreSQL database (%s) not found, removing function (%s) from state", databaseName, functionId)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	defer deferredRollback(txn)

--- a/postgresql/resource_postgresql_physical_replication_slot.go
+++ b/postgresql/resource_postgresql_physical_replication_slot.go
@@ -3,6 +3,8 @@ package postgresql
 import (
 	"database/sql"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -11,7 +13,6 @@ func resourcePostgreSQLPhysicalReplicationSlot() *schema.Resource {
 		Create: PGResourceFunc(resourcePostgreSQLPhysicalReplicationSlotCreate),
 		Read:   PGResourceFunc(resourcePostgreSQLPhysicalReplicationSlotRead),
 		Delete: PGResourceFunc(resourcePostgreSQLPhysicalReplicationSlotDelete),
-		Exists: PGResourceExistsFunc(resourcePostgreSQLPhysicalReplicationSlotExists),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -37,22 +38,20 @@ func resourcePostgreSQLPhysicalReplicationSlotCreate(db *DBConnection, d *schema
 	return nil
 }
 
-func resourcePostgreSQLPhysicalReplicationSlotExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
-	query := "SELECT 1 FROM pg_catalog.pg_replication_slots WHERE slot_name = $1 and slot_type = 'physical'"
-	var unused int
-	err := db.QueryRow(query, d.Id()).Scan(&unused)
+func resourcePostgreSQLPhysicalReplicationSlotRead(db *DBConnection, d *schema.ResourceData) error {
+	var slotName string
+	query := "SELECT slot_name FROM pg_catalog.pg_replication_slots WHERE slot_name = $1 AND slot_type = 'physical'"
+	err := db.QueryRow(query, d.Id()).Scan(&slotName)
 	switch {
 	case err == sql.ErrNoRows:
-		return false, nil
+		log.Printf("[WARN] PostgreSQL physical replication slot (%s) not found", d.Id())
+		d.SetId("")
+		return nil
 	case err != nil:
-		return false, err
+		return fmt.Errorf("error reading physical replication slot: %w", err)
 	}
 
-	return true, nil
-}
-
-func resourcePostgreSQLPhysicalReplicationSlotRead(db *DBConnection, d *schema.ResourceData) error {
-	d.Set("name", d.Id())
+	d.Set("name", slotName)
 	return nil
 }
 

--- a/postgresql/resource_postgresql_physical_replication_slot_test.go
+++ b/postgresql/resource_postgresql_physical_replication_slot_test.go
@@ -1,0 +1,147 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccPostgresqlPhysicalReplicationSlot_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlPhysicalReplicationSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "postgresql_physical_replication_slot" "myslot" {
+					name = "physical_slot"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlPhysicalReplicationSlotExists("postgresql_physical_replication_slot.myslot"),
+					resource.TestCheckResourceAttr(
+						"postgresql_physical_replication_slot.myslot", "name", "physical_slot"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccPostgresqlPhysicalReplicationSlot_Disappears ensures that a slot dropped
+// outside of Terraform is detected on the next refresh: Read must clear the ID so
+// the slot is planned for recreation (non-empty plan). This guards the Read-based
+// drift detection that replaced the removed Exists callback.
+func TestAccPostgresqlPhysicalReplicationSlot_Disappears(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlPhysicalReplicationSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "postgresql_physical_replication_slot" "myslot" {
+					name = "physical_slot"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlPhysicalReplicationSlotExists("postgresql_physical_replication_slot.myslot"),
+					testAccDropPhysicalReplicationSlot("physical_slot"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPostgresqlPhysicalReplicationSlotDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "postgresql_physical_replication_slot" {
+			continue
+		}
+
+		exists, err := checkPhysicalReplicationSlotExists(client, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking physical replication slot %s", err)
+		}
+
+		if exists {
+			return fmt.Errorf("PhysicalReplicationSlot still exists after destroy")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckPostgresqlPhysicalReplicationSlotExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client := testAccProvider.Meta().(*Client)
+		exists, err := checkPhysicalReplicationSlotExists(client, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking physical replication slot %s", err)
+		}
+
+		if !exists {
+			return fmt.Errorf("PhysicalReplicationSlot not found")
+		}
+
+		return nil
+	}
+}
+
+// testAccDropPhysicalReplicationSlot drops the slot directly, simulating an
+// out-of-band deletion (e.g. by an operator or another tool).
+func testAccDropPhysicalReplicationSlot(slotName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*Client)
+		db, err := client.Connect()
+		if err != nil {
+			return err
+		}
+
+		if _, err := db.Exec("SELECT pg_drop_replication_slot($1)", slotName); err != nil {
+			return fmt.Errorf("could not drop physical replication slot out-of-band: %w", err)
+		}
+
+		return nil
+	}
+}
+
+func checkPhysicalReplicationSlotExists(client *Client, slotName string) (bool, error) {
+	db, err := client.Connect()
+	if err != nil {
+		return false, err
+	}
+
+	var _rez bool
+	err = db.QueryRow(
+		"SELECT TRUE FROM pg_catalog.pg_replication_slots WHERE slot_name = $1 AND slot_type = 'physical'",
+		slotName,
+	).Scan(&_rez)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("error reading info about physical replication slot: %s", err)
+	}
+
+	return true, nil
+}

--- a/postgresql/resource_postgresql_physical_replication_slot_test.go
+++ b/postgresql/resource_postgresql_physical_replication_slot_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccPostgresqlPhysicalReplicationSlot_Basic(t *testing.T) {
+	skipIfNotAcc(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -38,6 +40,8 @@ func TestAccPostgresqlPhysicalReplicationSlot_Basic(t *testing.T) {
 // the slot is planned for recreation (non-empty plan). This guards the Read-based
 // drift detection that replaced the removed Exists callback.
 func TestAccPostgresqlPhysicalReplicationSlot_Disappears(t *testing.T) {
+	skipIfNotAcc(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)

--- a/postgresql/resource_postgresql_publication.go
+++ b/postgresql/resource_postgresql_publication.go
@@ -28,7 +28,6 @@ func resourcePostgreSQLPublication() *schema.Resource {
 		Read:   PGResourceFunc(resourcePostgreSQLPublicationRead),
 		Delete: PGResourceFunc(resourcePostgreSQLPublicationDelete),
 		Update: PGResourceFunc(resourcePostgreSQLPublicationUpdate),
-		Exists: PGResourceExistsFunc(resourcePostgreSQLPublicationExists),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -256,45 +255,6 @@ func resourcePostgreSQLPublicationCreate(db *DBConnection, d *schema.ResourceDat
 	d.SetId(generatePublicationID(d, databaseName))
 
 	return resourcePostgreSQLPublicationReadImpl(db, d)
-}
-
-func resourcePostgreSQLPublicationExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
-	if !db.featureSupported(featurePublication) {
-		return false, fmt.Errorf(
-			"postgresql_publication resource is not supported for this Postgres version (%s)",
-			db.version,
-		)
-	}
-
-	var PublicationName string
-
-	database, PublicationName, err := getDBPublicationName(d, db.client)
-	if err != nil {
-		return false, err
-	}
-
-	// Check if the database exists
-	exists, err := dbExists(db, database)
-	if err != nil || !exists {
-		return false, err
-	}
-
-	txn, err := startTransaction(db.client, database)
-	if err != nil {
-		return false, err
-	}
-	defer deferredRollback(txn)
-
-	query := "SELECT pubname FROM pg_catalog.pg_publication WHERE pubname = $1"
-	err = txn.QueryRow(query, pqQuoteLiteral(PublicationName)).Scan(&PublicationName)
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
-		return false, err
-	}
-
-	return true, nil
 }
 
 func resourcePostgreSQLPublicationRead(db *DBConnection, d *schema.ResourceData) error {

--- a/postgresql/resource_postgresql_publication.go
+++ b/postgresql/resource_postgresql_publication.go
@@ -281,7 +281,8 @@ func resourcePostgreSQLPublicationReadImpl(db *DBConnection, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("could not start transaction: %w", err)
+		// startTransaction already provides context; avoid double-wrapping.
+		return err
 	}
 	defer deferredRollback(txn)
 

--- a/postgresql/resource_postgresql_publication.go
+++ b/postgresql/resource_postgresql_publication.go
@@ -276,6 +276,11 @@ func resourcePostgreSQLPublicationReadImpl(db *DBConnection, d *schema.ResourceD
 
 	txn, err := startTransaction(db.client, database)
 	if err != nil {
+		if isDatabaseDoesNotExistError(err) {
+			log.Printf("[WARN] PostgreSQL database (%s) not found, removing publication (%s) from state", database, PublicationName)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("could not start transaction: %w", err)
 	}
 	defer deferredRollback(txn)

--- a/postgresql/resource_postgresql_replication_slot.go
+++ b/postgresql/resource_postgresql_replication_slot.go
@@ -14,7 +14,6 @@ func resourcePostgreSQLReplicationSlot() *schema.Resource {
 		Create: PGResourceFunc(resourcePostgreSQLReplicationSlotCreate),
 		Read:   PGResourceFunc(resourcePostgreSQLReplicationSlotRead),
 		Delete: PGResourceFunc(resourcePostgreSQLReplicationSlotDelete),
-		Exists: PGResourceExistsFunc(resourcePostgreSQLReplicationSlotExists),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -66,39 +65,6 @@ func resourcePostgreSQLReplicationSlotCreate(db *DBConnection, d *schema.Resourc
 	d.SetId(generateReplicationSlotID(d, databaseName))
 
 	return resourcePostgreSQLReplicationSlotReadImpl(db, d)
-}
-
-func resourcePostgreSQLReplicationSlotExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
-
-	var ReplicationSlotName string
-
-	database, replicationSlotName, err := getDBReplicationSlotName(d, db.client)
-	if err != nil {
-		return false, err
-	}
-
-	// Check if the database exists
-	exists, err := dbExists(db, database)
-	if err != nil || !exists {
-		return false, err
-	}
-
-	txn, err := startTransaction(db.client, database)
-	if err != nil {
-		return false, err
-	}
-	defer deferredRollback(txn)
-
-	query := "SELECT slot_name FROM pg_catalog.pg_replication_slots WHERE slot_name = $1 and database = $2"
-	err = txn.QueryRow(query, replicationSlotName, database).Scan(&ReplicationSlotName)
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
-		return false, err
-	}
-
-	return true, nil
 }
 
 func resourcePostgreSQLReplicationSlotRead(db *DBConnection, d *schema.ResourceData) error {

--- a/postgresql/resource_postgresql_replication_slot.go
+++ b/postgresql/resource_postgresql_replication_slot.go
@@ -76,6 +76,11 @@ func resourcePostgreSQLReplicationSlotReadImpl(db *DBConnection, d *schema.Resou
 	// NB: we use initConnection instead of startTransaction so that replication slots can be managed on replica servers too, for cascading replication
 	dbc, err := initConnection(db.client, database)
 	if err != nil {
+		if isDatabaseDoesNotExistError(err) {
+			log.Printf("[WARN] PostgreSQL database (%s) not found, removing replication slot (%s) from state", database, replicationSlotName)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 
@@ -87,6 +92,10 @@ func resourcePostgreSQLReplicationSlotReadImpl(db *DBConnection, d *schema.Resou
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL ReplicationSlot (%s) not found for database %s", replicationSlotName, database)
+		d.SetId("")
+		return nil
+	case isDatabaseDoesNotExistError(err):
+		log.Printf("[WARN] PostgreSQL database %s not found, removing replication slot %s from state", database, replicationSlotName)
 		d.SetId("")
 		return nil
 	case err != nil:

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -49,7 +49,6 @@ func resourcePostgreSQLRole() *schema.Resource {
 		Read:   PGResourceFunc(resourcePostgreSQLRoleRead),
 		Update: PGResourceFunc(resourcePostgreSQLRoleUpdate),
 		Delete: PGResourceFunc(resourcePostgreSQLRoleDelete),
-		Exists: PGResourceExistsFunc(resourcePostgreSQLRoleExists),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -420,19 +419,6 @@ func resourcePostgreSQLRoleDelete(db *DBConnection, d *schema.ResourceData) erro
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePostgreSQLRoleExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
-	var roleName string
-	err := db.QueryRow("SELECT rolname FROM pg_catalog.pg_roles WHERE rolname=$1", d.Id()).Scan(&roleName)
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
-		return false, err
-	}
-
-	return true, nil
 }
 
 func resourcePostgreSQLRoleRead(db *DBConnection, d *schema.ResourceData) error {

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -35,7 +35,6 @@ func resourcePostgreSQLSchema() *schema.Resource {
 		Read:   PGResourceFunc(resourcePostgreSQLSchemaRead),
 		Update: PGResourceFunc(resourcePostgreSQLSchemaUpdate),
 		Delete: PGResourceFunc(resourcePostgreSQLSchemaDelete),
-		Exists: PGResourceExistsFunc(resourcePostgreSQLSchemaExists),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -273,35 +272,6 @@ func resourcePostgreSQLSchemaDelete(db *DBConnection, d *schema.ResourceData) er
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePostgreSQLSchemaExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
-	database, schemaName, err := getDBSchemaName(d, db.client.databaseName)
-	if err != nil {
-		return false, err
-	}
-
-	// Check if the database exists
-	exists, err := dbExists(db, database)
-	if err != nil || !exists {
-		return false, err
-	}
-
-	txn, err := startTransaction(db.client, database)
-	if err != nil {
-		return false, err
-	}
-	defer deferredRollback(txn)
-
-	err = txn.QueryRow("SELECT n.nspname FROM pg_catalog.pg_namespace n WHERE n.nspname=$1", schemaName).Scan(&schemaName)
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
-		return false, fmt.Errorf("error reading schema: %w", err)
-	}
-
-	return true, nil
 }
 
 func resourcePostgreSQLSchemaRead(db *DBConnection, d *schema.ResourceData) error {

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -286,6 +286,11 @@ func resourcePostgreSQLSchemaReadImpl(db *DBConnection, d *schema.ResourceData) 
 
 	txn, err := startTransaction(db.client, database)
 	if err != nil {
+		if isDatabaseDoesNotExistError(err) {
+			log.Printf("[WARN] PostgreSQL database (%s) not found, removing schema (%s) from state", database, schemaName)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	defer deferredRollback(txn)

--- a/postgresql/resource_postgresql_schema_test.go
+++ b/postgresql/resource_postgresql_schema_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/lib/pq"
 )
 
 func TestAccPostgresqlSchema_Basic(t *testing.T) {
@@ -597,3 +598,61 @@ resource "postgresql_schema" "test4" {
   }
 }
 `
+
+// TestAccPostgresqlSchema_DatabaseDropped ensures that when the database holding
+// a schema is dropped out-of-band, the read prunes the resource from state
+// instead of failing the whole refresh with `database "..." does not exist`
+// (SQLSTATE 3D000). Removing the Exists callback moved gone-detection entirely
+// into Read, which connects to the target database and therefore has to treat a
+// missing database as "resource gone" rather than an error.
+func TestAccPostgresqlSchema_DatabaseDropped(t *testing.T) {
+	skipIfNotAcc(t)
+
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+
+	dbName, _ := getTestDBNames(dbSuffix)
+
+	config := fmt.Sprintf(`
+resource "postgresql_schema" "test" {
+	name     = "test_dropped_db_schema"
+	database = "%s"
+}
+`, dbName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlSchemaDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlSchemaExists("postgresql_schema.test", "test_dropped_db_schema"),
+					testAccDropDatabase(t, dbName),
+				),
+				// The database (and its schema) is gone out-of-band: the following
+				// refresh must succeed and plan to recreate the resource instead of
+				// erroring, which is what this change fixes.
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// testAccDropDatabase drops a database out-of-band. It terminates any lingering
+// backends first so the drop succeeds on all supported server versions, which
+// predate `DROP DATABASE ... WITH (FORCE)`.
+func testAccDropDatabase(t *testing.T, dbName string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		config := getTestConfig(t)
+		dbExecute(t, config.connStr("postgres"),
+			"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+			dbName)
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf("DROP DATABASE %s", pq.QuoteIdentifier(dbName)))
+		return nil
+	}
+}

--- a/postgresql/resource_postgresql_subscription.go
+++ b/postgresql/resource_postgresql_subscription.go
@@ -1,7 +1,6 @@
 package postgresql
 
 import (
-	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -16,7 +15,6 @@ func resourcePostgreSQLSubscription() *schema.Resource {
 		Create:   PGResourceFunc(resourcePostgreSQLSubscriptionCreate),
 		Read:     PGResourceFunc(resourcePostgreSQLSubscriptionRead),
 		Delete:   PGResourceFunc(resourcePostgreSQLSubscriptionDelete),
-		Exists:   PGResourceExistsFunc(resourcePostgreSQLSubscriptionExists),
 		Importer: &schema.ResourceImporter{StateContext: schema.ImportStatePassthroughContext},
 
 		Schema: map[string]*schema.Schema{
@@ -209,39 +207,6 @@ func resourcePostgreSQLSubscriptionDelete(db *DBConnection, d *schema.ResourceDa
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePostgreSQLSubscriptionExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
-	var subName string
-
-	database, subName, err := getDBSubscriptionName(d, db.client)
-	if err != nil {
-		return false, err
-	}
-
-	// Check if the database exists
-	exists, err := dbExists(db, database)
-	if err != nil || !exists {
-		return false, err
-	}
-
-	txn, err := startTransaction(db.client, database)
-	if err != nil {
-		return false, err
-	}
-	defer deferredRollback(txn)
-
-	query := "SELECT subname from pg_catalog.pg_stat_subscription WHERE subname = $1"
-	err = txn.QueryRow(query, pqQuoteLiteral(subName)).Scan(&subName)
-
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
-		return false, err
-	}
-
-	return true, nil
 }
 
 func getPublicationsForSubscription(d *schema.ResourceData) (string, error) {

--- a/postgresql/resource_postgresql_subscription.go
+++ b/postgresql/resource_postgresql_subscription.go
@@ -115,6 +115,11 @@ func resourcePostgreSQLSubscriptionReadImpl(db *DBConnection, d *schema.Resource
 
 	txn, err := startTransaction(db.client, databaseName)
 	if err != nil {
+		if isDatabaseDoesNotExistError(err) {
+			log.Printf("[WARN] PostgreSQL database (%s) not found, removing subscription (%s) from state", databaseName, subName)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("could not start transaction: %w", err)
 	}
 	defer deferredRollback(txn)

--- a/postgresql/resource_postgresql_subscription.go
+++ b/postgresql/resource_postgresql_subscription.go
@@ -120,7 +120,8 @@ func resourcePostgreSQLSubscriptionReadImpl(db *DBConnection, d *schema.Resource
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("could not start transaction: %w", err)
+		// startTransaction already provides context; avoid double-wrapping.
+		return err
 	}
 	defer deferredRollback(txn)
 
@@ -133,7 +134,7 @@ func resourcePostgreSQLSubscriptionReadImpl(db *DBConnection, d *schema.Resource
 	// A missing subscription yields no row, so QueryRow returns ErrNoRows.
 	// Treat that as "gone" and clear the ID (this used to be handled by the
 	// now-removed Exists callback); anything else is a real error.
-	switch err = txn.QueryRow(queryExists, pqQuoteLiteral(subName)).Scan(&subExists); {
+	switch err = txn.QueryRow(queryExists, subName).Scan(&subExists); {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL Subscription (%s) not found for database %s", subName, databaseName)
 		d.SetId("")
@@ -144,7 +145,7 @@ func resourcePostgreSQLSubscriptionReadImpl(db *DBConnection, d *schema.Resource
 
 	// pg_subscription requires superuser permissions, it is okay to fail here
 	query := "SELECT subconninfo, subpublications, subslotname FROM pg_catalog.pg_subscription WHERE subname = $1"
-	err = txn.QueryRow(query, pqQuoteLiteral(subName)).Scan(&connInfo, pq.Array(&publications), &slotName)
+	err = txn.QueryRow(query, subName).Scan(&connInfo, pq.Array(&publications), &slotName)
 
 	if err != nil {
 		// we already checked that the subscription exists

--- a/postgresql/resource_postgresql_subscription.go
+++ b/postgresql/resource_postgresql_subscription.go
@@ -1,6 +1,7 @@
 package postgresql
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -124,15 +125,16 @@ func resourcePostgreSQLSubscriptionReadImpl(db *DBConnection, d *schema.Resource
 
 	var subExists bool
 	queryExists := "SELECT TRUE FROM pg_catalog.pg_stat_subscription WHERE subname = $1"
-	err = txn.QueryRow(queryExists, pqQuoteLiteral(subName)).Scan(&subExists)
-	if err != nil {
-		return fmt.Errorf("failed to check subscription: %w", err)
-	}
-
-	if !subExists {
+	// A missing subscription yields no row, so QueryRow returns ErrNoRows.
+	// Treat that as "gone" and clear the ID (this used to be handled by the
+	// now-removed Exists callback); anything else is a real error.
+	switch err = txn.QueryRow(queryExists, pqQuoteLiteral(subName)).Scan(&subExists); {
+	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL Subscription (%s) not found for database %s", subName, databaseName)
 		d.SetId("")
 		return nil
+	case err != nil:
+		return fmt.Errorf("failed to check subscription: %w", err)
 	}
 
 	// pg_subscription requires superuser permissions, it is okay to fail here

--- a/postgresql/resource_postgresql_subscription_test.go
+++ b/postgresql/resource_postgresql_subscription_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/lib/pq"
 )
 
 func testAccCheckPostgresqlSubscriptionDestroy(s *terraform.State) error {
@@ -229,6 +230,83 @@ func TestAccPostgresqlSubscription_Basic(t *testing.T) {
 		},
 	},
 	)
+	coolDown()
+}
+
+// testAccDropSubscription drops a subscription out-of-band, without touching
+// the remote replication slot (which is managed by a separate resource here):
+// disable it, detach the slot, then drop it.
+func testAccDropSubscription(t *testing.T, dbName, subName string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		config := getTestConfig(t)
+		dsn := config.connStr(dbName)
+		dbExecute(t, dsn, fmt.Sprintf("ALTER SUBSCRIPTION %s DISABLE", pq.QuoteIdentifier(subName)))
+		dbExecute(t, dsn, fmt.Sprintf("ALTER SUBSCRIPTION %s SET (slot_name = NONE)", pq.QuoteIdentifier(subName)))
+		dbExecute(t, dsn, fmt.Sprintf("DROP SUBSCRIPTION %s", pq.QuoteIdentifier(subName)))
+		return nil
+	}
+}
+
+// TestAccPostgresqlSubscription_Disappears verifies that when a subscription is
+// dropped out-of-band, a refresh detects it as gone (Read clears the ID) and
+// plans to recreate it, rather than erroring. This guards the Read not-found
+// path that used to be covered by the now-removed Exists callback.
+func TestAccPostgresqlSubscription_Disappears(t *testing.T) {
+	skipIfNotAcc(t)
+
+	dbSuffixPub, teardownPub := setupTestDatabase(t, true, true)
+	dbSuffixSub, teardownSub := setupTestDatabase(t, true, true)
+
+	defer teardownPub()
+	defer teardownSub()
+	testTables := []string{"test_schema.test_table_1"}
+	createTestTables(t, dbSuffixPub, testTables, "")
+	createTestTables(t, dbSuffixSub, testTables, "")
+
+	dbNamePub, _ := getTestDBNames(dbSuffixPub)
+	dbNameSub, _ := getTestDBNames(dbSuffixSub)
+
+	conninfo := getConnInfo(t, dbNamePub)
+
+	subName := "subscription"
+	config := fmt.Sprintf(`
+	resource "postgresql_publication" "test_pub" {
+		name     	= "test_publication"
+		database	= "%s"
+		tables		= ["test_schema.test_table_1"]
+	}
+	resource "postgresql_replication_slot" "test_replication_slot" {
+		name		= "%s"
+		database	= "%s"
+		plugin		= "pgoutput"
+	}
+	resource "postgresql_subscription" "test_sub" {
+		name     		= postgresql_replication_slot.test_replication_slot.name
+		database 		= "%s"
+		conninfo 		= "%s"
+		publications	= [ postgresql_publication.test_pub.name ]
+		create_slot		= false
+	}
+	`, dbNamePub, subName, dbNamePub, dbNameSub, conninfo)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlSubscriptionExists("postgresql_subscription.test_sub"),
+					testAccDropSubscription(t, dbNameSub, subName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
 	coolDown()
 }
 


### PR DESCRIPTION
### What

SDKv2 already supports gone-resource detection through `Read` + `d.SetId("")`: when a resource has no `Exists` callback, the framework treats an empty ID after `Read` as "resource deleted" and prunes it from state. This provider additionally defined `Exists` for 9 resources, and in every case the `Exists` callback issued the same catalog lookup that `Read` already performs. During refresh that means two round-trips (and, with `SetMaxIdleConns(0)`, often two connection setups) where one would do.

This PR:

- **Removes 8 redundant no-op `Exists` callbacks** — `postgresql_database`, `postgresql_extension`, `postgresql_function`, `postgresql_replication_slot`, `postgresql_publication`, `postgresql_role`, `postgresql_schema`, `postgresql_subscription`. Each resource's `Read` already calls `d.SetId("")` on not-found, so behaviour is unchanged and per-resource refresh round-trips are roughly halved.
- **Fixes a latent drift bug in `postgresql_physical_replication_slot`.** Its `Read` was a no-op (`d.Set("name", d.Id())`) and drift detection depended entirely on `Exists`. `Read` is rewritten to query `pg_catalog.pg_replication_slots` and `d.SetId("")` when the slot is gone, so an out-of-band `pg_drop_replication_slot` is now detected on refresh. (Removing its `Exists` without this rewrite would have silently broken drift detection — hence it is fixed and tested here.)
- **Preserves parent-database pruning for database-scoped resources.** The removed `Exists` short-circuited via `dbExists(parentDB)` and reported the child as gone when the parent database was absent. That short-circuit is reproduced in `Read`: for `extension`, `function`, `schema`, `publication`, `replication_slot` and `subscription`, `Read` detects `SQLSTATE 3D000` (`invalid_catalog_name`) when it opens the connection/transaction to the parent DB and prunes the resource (`d.SetId("")`), matching the pre-removal behaviour. Detection inspects the error the connection already returns, so it adds no extra round-trip. `grant` and `default_privileges` keep their explicit `dbExists` pre-check (via `checkRoleDBSchemaExists`) and are unchanged.
- **Fixes a latent not-found bug in `postgresql_subscription` `Read`** exposed by removing `Exists`: it returned an error on `sql.ErrNoRows` from the existence probe (and had a dead `if !subExists` branch) instead of pruning. `Read` now clears the ID on `ErrNoRows`, matching the other resources.
- **Deletes the now-unused `PGResourceExistsFunc` helper.** It is exported, so `golangci-lint`'s `unused` linter does not flag it; removed by hand.

### Why

Halve refresh round-trips for these resource types and remove a "two queries for one check" pattern, while fixing the resources whose drift detection actually depended on `Exists`.

### Behaviour changes to be aware of

- **physical_replication_slot:** out-of-band slot drops are now detected on refresh (previously the resource was never flagged as gone). This PR makes the removal safe and adds a test for it.
- **Parent-database drops:** deleting a parent database out-of-band and then refreshing a database-scoped child prunes the child from state (recreate on next apply), the same outcome the removed `Exists` produced. In normal flows the `postgresql_database` resource's own drift already drives recreation.
- **Connection error handling:** `config.go`'s `Connect()` now wraps `*pq.Error` with `%w` (instead of flattening it to a string) so callers can inspect the SQLSTATE. Server-side pq errors never carry the password; connection/DSN errors, which can, keep the existing redaction, so the rendered message is unchanged.
- **Version guards preserved:** the unsupported-PG-version hard error previously returned by the version-gated `Exists` callbacks (extension / function / publication) is returned identically by their `Read` functions, so the guard is intact.

### Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean, unit tests pass.
- New `postgresql_physical_replication_slot` acceptance test (create + out-of-band-drop drift).
- New `TestAccPostgresqlSchema_DatabaseDropped` acceptance test: create a schema, drop its database out-of-band, and assert the refresh prunes it instead of erroring (it fails against the pre-fix code with `pq: database "..." does not exist (3D000)`).
- Existing acceptance tests for the other 8 resources (each with `CheckDestroy`) cover the refresh + pruning behaviour across the PG 12–18 CI matrix.
- Ran locally against PostgreSQL 16 (superuser profile): the new tests plus the existing tests for all affected resources (role, schema, database, extension, function, publication, replication_slot, subscription) pass; under the rds (non-superuser) profile the non-replication subset passes and the superuser-gated tests skip as expected.
