### PR TITLE
Reduce round-trips in database and grant_role Read

### DIFF
--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -314,40 +314,41 @@ func resourcePostgreSQLDatabaseRead(db *DBConnection, d *schema.ResourceData) er
 
 func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData) error {
 	dbId := d.Id()
-	var dbName, ownerName string
-	err := db.QueryRow("SELECT d.datname, pg_catalog.pg_get_userbyid(d.datdba) from pg_database d WHERE datname=$1", dbId).Scan(&dbName, &ownerName)
-	switch {
-	case err == sql.ErrNoRows:
-		log.Printf("[WARN] PostgreSQL database (%q) not found", dbId)
-		d.SetId("")
-		return nil
-	case err != nil:
-		return fmt.Errorf("error reading database: %w", err)
-	}
 
-	var dbEncoding, dbCollation, dbCType, dbTablespaceName string
+	var dbName, ownerName, dbEncoding, dbCollation, dbCType string
 	var dbConnLimit int
+	var dbAllowConns, dbIsTemplate bool
+	// ts.spcname is scanned via sql.NullString because the LEFT JOIN to
+	// pg_tablespace yields NULL if the database's tablespace cannot be
+	// resolved (in practice it always can). Using a LEFT JOIN keeps the row
+	// instead of dropping it, which an INNER JOIN would do.
+	var dbTablespaceName sql.NullString
 
-	columns := []string{
-		"pg_catalog.pg_encoding_to_char(d.encoding)",
-		"d.datcollate",
-		"d.datctype",
-		"ts.spcname",
-		"d.datconnlimit",
-	}
-
-	dbSQLFmt := `SELECT %s ` +
-		`FROM pg_catalog.pg_database AS d, pg_catalog.pg_tablespace AS ts ` +
-		`WHERE d.datname = $1 AND d.dattablespace = ts.oid`
-	dbSQL := fmt.Sprintf(dbSQLFmt, strings.Join(columns, ", "))
-	err = db.QueryRow(dbSQL, dbId).
-		Scan(
-			&dbEncoding,
-			&dbCollation,
-			&dbCType,
-			&dbTablespaceName,
-			&dbConnLimit,
-		)
+	// All database attributes are read in a single query to avoid the extra
+	// round-trips of the previous implementation (which issued four separate
+	// queries against pg_database for the same row). datallowconn and
+	// datistemplate exist on every supported server version, so they are always
+	// selected; the per-version feature gates are applied only when writing them
+	// into state (below) to preserve the previous behavior.
+	query := `SELECT d.datname, ` +
+		`pg_catalog.pg_get_userbyid(d.datdba), ` +
+		`pg_catalog.pg_encoding_to_char(d.encoding), ` +
+		`d.datcollate, d.datctype, ts.spcname, d.datconnlimit, ` +
+		`d.datallowconn, d.datistemplate ` +
+		`FROM pg_catalog.pg_database d ` +
+		`LEFT JOIN pg_catalog.pg_tablespace ts ON d.dattablespace = ts.oid ` +
+		`WHERE d.datname = $1`
+	err := db.QueryRow(query, dbId).Scan(
+		&dbName,
+		&ownerName,
+		&dbEncoding,
+		&dbCollation,
+		&dbCType,
+		&dbTablespaceName,
+		&dbConnLimit,
+		&dbAllowConns,
+		&dbIsTemplate,
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL database (%q) not found", dbId)
@@ -362,7 +363,7 @@ func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData
 	d.Set(dbEncodingAttr, dbEncoding)
 	d.Set(dbCollationAttr, dbCollation)
 	d.Set(dbCTypeAttr, dbCType)
-	d.Set(dbTablespaceAttr, dbTablespaceName)
+	d.Set(dbTablespaceAttr, dbTablespaceName.String)
 	d.Set(dbConnLimitAttr, dbConnLimit)
 	dbTemplate := d.Get(dbTemplateAttr).(string)
 	if dbTemplate == "" {
@@ -371,24 +372,10 @@ func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData
 	d.Set(dbTemplateAttr, dbTemplate)
 
 	if db.featureSupported(featureDBAllowConnections) {
-		var dbAllowConns bool
-		dbSQL := fmt.Sprintf(dbSQLFmt, "d.datallowconn")
-		err = db.QueryRow(dbSQL, dbId).Scan(&dbAllowConns)
-		if err != nil {
-			return fmt.Errorf("error reading ALLOW_CONNECTIONS property for DATABASE: %w", err)
-		}
-
 		d.Set(dbAllowConnsAttr, dbAllowConns)
 	}
 
 	if db.featureSupported(featureDBIsTemplate) {
-		var dbIsTemplate bool
-		dbSQL := fmt.Sprintf(dbSQLFmt, "d.datistemplate")
-		err = db.QueryRow(dbSQL, dbId).Scan(&dbIsTemplate)
-		if err != nil {
-			return fmt.Errorf("error reading IS_TEMPLATE property for DATABASE: %w", err)
-		}
-
 		d.Set(dbIsTemplateAttr, dbIsTemplate)
 	}
 

--- a/postgresql/resource_postgresql_grant_role.go
+++ b/postgresql/resource_postgresql_grant_role.go
@@ -12,17 +12,23 @@ import (
 )
 
 const (
-	// This returns the role membership for role, grant_role
+	// This returns the role membership for role, grant_role.
+	// The membership is looked up by joining pg_auth_members to pg_roles on
+	// the member/roleid OIDs so the filter can use the rolname index, instead
+	// of calling pg_get_userbyid() on every row of pg_auth_members in WHERE
+	// (which forces a sequential function scan on large installations).
 	getGrantRoleQuery = `
 SELECT
-  pg_get_userbyid(member) as role,
-  pg_get_userbyid(roleid) as grant_role,
-  admin_option
+  ur.rolname as role,
+  gr.rolname as grant_role,
+  m.admin_option
 FROM
-  pg_auth_members
+  pg_auth_members m
+  JOIN pg_roles ur ON ur.oid = m.member
+  JOIN pg_roles gr ON gr.oid = m.roleid
 WHERE
-  pg_get_userbyid(member) = $1 AND
-  pg_get_userbyid(roleid) = $2;
+  ur.rolname = $1 AND
+  gr.rolname = $2;
 `
 )
 

--- a/postgresql/resource_postgresql_grant_role_test.go
+++ b/postgresql/resource_postgresql_grant_role_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -50,6 +51,35 @@ func TestCreateGrantRoleQuery(t *testing.T) {
 		if out != c.expected {
 			t.Fatalf("error matching output and expected: %#v vs %#v", out, c.expected)
 		}
+	}
+}
+
+// TestGetGrantRoleQuery locks in the OID-join form of the Read query. The
+// membership must be filtered by joining pg_auth_members to pg_roles on the
+// member/roleid OIDs, NOT by calling pg_get_userbyid() in the WHERE clause
+// (which forces a sequential function scan on large installations). This guards
+// against an accidental regression to the function-scan form.
+func TestGetGrantRoleQuery(t *testing.T) {
+	expected := `
+SELECT
+  ur.rolname as role,
+  gr.rolname as grant_role,
+  m.admin_option
+FROM
+  pg_auth_members m
+  JOIN pg_roles ur ON ur.oid = m.member
+  JOIN pg_roles gr ON gr.oid = m.roleid
+WHERE
+  ur.rolname = $1 AND
+  gr.rolname = $2;
+`
+
+	if getGrantRoleQuery != expected {
+		t.Fatalf("getGrantRoleQuery changed unexpectedly:\n got: %q\nwant: %q", getGrantRoleQuery, expected)
+	}
+
+	if strings.Contains(getGrantRoleQuery, "pg_get_userbyid") {
+		t.Fatalf("getGrantRoleQuery must not call pg_get_userbyid (regression to function scan): %q", getGrantRoleQuery)
 	}
 }
 

--- a/postgresql/resource_postgresql_grant_role_test.go
+++ b/postgresql/resource_postgresql_grant_role_test.go
@@ -74,7 +74,7 @@ WHERE
   gr.rolname = $2;
 `
 
-	if getGrantRoleQuery != expected {
+	if strings.Join(strings.Fields(getGrantRoleQuery), " ") != strings.Join(strings.Fields(expected), " ") {
 		t.Fatalf("getGrantRoleQuery changed unexpectedly:\n got: %q\nwant: %q", getGrantRoleQuery, expected)
 	}
 


### PR DESCRIPTION
## What

Two behavior-preserving optimizations on the resource `Read` path, which runs for every resource on each `plan`/`apply` and therefore directly affects refresh time on large configurations.

### `postgresql_database`

`resourcePostgreSQLDatabaseReadImpl` issued **four separate queries** against `pg_database` for the same row:

1. `datname` + owner
2. encoding / collation / ctype / tablespace / connlimit
3. `datallowconn` (version-gated)
4. `datistemplate` (version-gated)

These are collapsed into a **single `SELECT`**. `datallowconn`/`datistemplate` exist on every supported server version, so they are always fetched; the existing per-version feature gates are kept on the `d.Set` side, so what gets written into state is unchanged.

### `postgresql_grant_role`

`getGrantRoleQuery` filtered the membership with `pg_get_userbyid(member) = $1 AND pg_get_userbyid(roleid) = $2`. Applying a function to every row of `pg_auth_members` prevents an index lookup and forces a sequential function scan, which is noticeable on installations with many role memberships.

The filter now joins `pg_auth_members` to `pg_roles` on the `member`/`roleid` OIDs, so the `rolname` index is used. The returned columns, parameter order and not-found handling are unchanged. This matches the OID-join idiom already used in `resource_postgresql_role.go`.

## Behavior

Both changes are behavior-preserving, with no schema/API change and no new privilege requirements.

One intentional edge-case improvement worth calling out: the database tablespace join changes from an implicit **INNER** join to a **LEFT** join (with `sql.NullString`). Previously, if a database's tablespace could not be resolved, the second query returned no rows and the resource was silently dropped from state (`ErrNoRows` → empty ID). It is now kept with an empty tablespace. This also removes a pre-existing inconsistency between the old name/owner query (no join) and the other three (inner join). In practice `dattablespace` always resolves, so this path is rarely if ever hit.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` — clean
- Unit tests pass, including a new snapshot test (`TestGetGrantRoleQuery`) that locks in the OID-join form and guards against a regression to the function-scan query
- Existing acceptance tests cover the affected attributes round-trip: `TestAccPostgresqlGrantRole`, `TestAccPostgresqlDatabase_*` (owner, encoding, connection_limit, allow_connections, is_template, tablespace)
- Ran these acceptance tests locally against PostgreSQL 16 while CI is pending, green under both profiles: **superuser** — `TestAccPostgresqlGrantRole` and all `TestAccPostgresqlDatabase_*` pass; **rds** (non-superuser) — same set passes, with `TestAccPostgresqlDatabase_AlterObjectOwnership` skipped by its built-in superuser gate (not a regression)

