### PR TITLE
Push objects filter into SQL when reading table/sequence grants

### DIFF
--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -430,6 +430,42 @@ ORDER BY col_privs.attname
 	return nil
 }
 
+// buildReadTableRolePrivilegesQuery builds the Read query and bind arguments
+// for the table/sequence object types. When the resource lists explicit
+// objects, the relname filter is pushed into the query (relname = ANY) instead
+// of fetching every relation of this relkind in the schema and discarding the
+// surplus afterwards; on schemas with many relations this avoids transferring
+// rows that are immediately dropped. An empty objects set means "all objects in
+// the schema", so the predicate is only added when objects are listed — the
+// empty case returns the original query and three-argument bind list.
+func buildReadTableRolePrivilegesQuery(roleOID uint32, schemaName, relkind string, objects *schema.Set) (string, []interface{}) {
+	query := `
+SELECT pg_class.relname, array_remove(array_agg(privilege_type), NULL)
+FROM pg_class
+JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+LEFT JOIN (
+    SELECT acls.* FROM (
+        SELECT relname, relnamespace, relkind, (aclexplode(relacl)).* FROM pg_class c
+    ) as acls
+    WHERE grantee=$1
+) privs
+USING (relname, relnamespace, relkind)
+WHERE nspname = $2 AND relkind = $3`
+	args := []interface{}{roleOID, schemaName, relkind}
+
+	if objects.Len() > 0 {
+		objectNames := make([]string, 0, objects.Len())
+		for _, o := range objects.List() {
+			objectNames = append(objectNames, o.(string))
+		}
+		query += " AND pg_class.relname = ANY($4)"
+		args = append(args, pq.Array(objectNames))
+	}
+	query += "\nGROUP BY pg_class.relname\n"
+
+	return query, args
+}
+
 func readRolePrivileges(txn *sql.Tx, db *DBConnection, d *schema.ResourceData) error {
 	role := d.Get("role").(string)
 	objectType := d.Get("object_type").(string)
@@ -480,23 +516,11 @@ GROUP BY pg_proc.proname
 		return readColumnRolePrivileges(txn, d)
 
 	default:
-		query = `
-SELECT pg_class.relname, array_remove(array_agg(privilege_type), NULL)
-FROM pg_class
-JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
-LEFT JOIN (
-    SELECT acls.* FROM (
-        SELECT relname, relnamespace, relkind, (aclexplode(relacl)).* FROM pg_class c
-    ) as acls
-    WHERE grantee=$1
-) privs
-USING (relname, relnamespace, relkind)
-WHERE nspname = $2 AND relkind = $3
-GROUP BY pg_class.relname
-`
-		rows, err = txn.Query(
-			query, roleOID, d.Get("schema"), objectTypes[objectType],
+		var args []interface{}
+		query, args = buildReadTableRolePrivilegesQuery(
+			roleOID, d.Get("schema").(string), objectTypes[objectType], objects,
 		)
+		rows, err = txn.Query(query, args...)
 	}
 
 	// This returns, for the specified role (rolname),
@@ -516,6 +540,10 @@ GROUP BY pg_class.relname
 			return err
 		}
 
+		// For the table/sequence path this set is already filtered in SQL
+		// above; the check is kept because the function/procedure/routine path
+		// still fetches every object in the schema (its object names may carry
+		// argument signatures, so it is filtered here rather than in SQL).
 		if objects.Len() > 0 && !objects.Contains(objName) {
 			continue
 		}

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -13,6 +13,44 @@ import (
 	"github.com/lib/pq"
 )
 
+// TestBuildReadTableRolePrivilegesQuery locks in the table/sequence Read query
+// shape. With an empty objects set the query must stay unfiltered and bind
+// exactly three arguments ("empty means all objects in the schema"). With an
+// explicit objects list the relname filter must be pushed into SQL as
+// "relname = ANY($4)" with a fourth bind argument, so the whole schema is not
+// transferred only to be discarded by the Go filter afterwards.
+func TestBuildReadTableRolePrivilegesQuery(t *testing.T) {
+	roleOID := uint32(1234)
+
+	emptyQuery, emptyArgs := buildReadTableRolePrivilegesQuery(
+		roleOID, "test_schema", "r", schema.NewSet(schema.HashString, nil),
+	)
+	if strings.Contains(emptyQuery, "ANY(") {
+		t.Fatalf("empty objects must not push a relname filter, got: %q", emptyQuery)
+	}
+	if len(emptyArgs) != 3 {
+		t.Fatalf("empty objects must bind 3 args, got %d: %#v", len(emptyArgs), emptyArgs)
+	}
+
+	objects := schema.NewSet(schema.HashString, []interface{}{"test_table", "test_table2"})
+	query, args := buildReadTableRolePrivilegesQuery(roleOID, "test_schema", "r", objects)
+	if !strings.Contains(query, "AND pg_class.relname = ANY($4)") {
+		t.Fatalf("explicit objects must push relname = ANY($4), got: %q", query)
+	}
+	if len(args) != 4 {
+		t.Fatalf("explicit objects must bind 4 args, got %d: %#v", len(args), args)
+	}
+
+	for _, q := range []string{emptyQuery, query} {
+		if !strings.Contains(q, "GROUP BY pg_class.relname") {
+			t.Fatalf("query missing GROUP BY pg_class.relname: %q", q)
+		}
+		if !strings.Contains(q, "SELECT pg_class.relname, array_remove(array_agg(privilege_type), NULL)") {
+			t.Fatalf("query changed its selected columns: %q", q)
+		}
+	}
+}
+
 func TestCreateGrantQuery(t *testing.T) {
 	var databaseName = "foo"
 	var roleName = "bar"


### PR DESCRIPTION
## What

When reading `postgresql_grant` for table/sequence object types, push the
`objects` filter into SQL instead of fetching every relation of the requested
relkind in the schema and discarding the surplus in Go.

`readRolePrivileges` currently runs:

```sql
... WHERE nspname = $2 AND relkind = $3
GROUP BY pg_class.relname
```

which returns **all** relations of that relkind in the schema, and then a Go
loop skips the ones not listed in the resource's `objects`. On a schema with
many tables/sequences this transfers a large result set on every read just to
throw most of it away.

## Change

When `objects` is non-empty, append `AND pg_class.relname = ANY($4)` (bound via
`pq.Array`) so PostgreSQL returns only the requested relations. The query and
bind list are built in a small helper, `buildReadTableRolePrivilegesQuery`.

An empty `objects` set means "all objects in the schema" (the documented
contract), so the predicate is added **only** when objects are listed — the
empty case keeps the original query and the original three-argument bind list.

## Scope / behavior

- **No behavior change.** Identifier matching uses the same raw text equality
  the Go filter used (`relname = ANY(...)` vs `objects.Contains`), and the
  empty-objects path is untouched.
- The **function/procedure/routine** path is left unchanged on purpose: its
  object names may carry argument signatures (e.g. `test(text, char)`) that do
  not match the bare `proname`, so it is still filtered in Go.
- The Go filter in the read loop is kept as a harmless no-op for the now
  pre-filtered table/sequence rows; it remains load-bearing for the function
  path (a comment explains this).

## Testing

- New unit test `TestBuildReadTableRolePrivilegesQuery` asserts the predicate is
  added (and a 4th arg bound) only for explicit objects, and that the empty case
  stays unfiltered with 3 args.
- `go build ./...`, `go vet ./postgresql/`, `gofmt`, and `go test ./postgresql/`
  all pass.
- Acceptance tests run against a real PostgreSQL 16, green under both the
  superuser and the rds (non-superuser) profiles:
  `TestAccPostgresqlGrant`, `TestAccPostgresqlGrantObjects`,
  `TestAccPostgresqlGrantObjectsError`, `TestAccPostgresqlGrantColumns`,
  `TestAccPostgresqlGrantPublic`, `TestAccPostgresqlGrantEmptyPrivileges`,
  `TestAccPostgresqlGrantFunction`, `TestAccPostgresqlGrantFunctionWithArgs`,
  `TestAccPostgresqlGrantProcedure`, `TestAccPostgresqlGrantRoutine`.
