### PR TITLE
replication_slot resource : stop using transactions, so that the resource can be used on a replica

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -384,14 +384,28 @@ func setToPgIdentSimpleList(idents *schema.Set) string {
 	return strings.Join(quotedIdents, ",")
 }
 
-// startTransaction starts a new DB transaction on the specified database.
+// initConnection starts a new DB connection on the specified database, if necessary
 // If the database is specified and different from the one configured in the provider,
-// it will create a new connection pool if needed.
-func startTransaction(client *Client, database string) (*sql.Tx, error) {
+// we need to create a new connection pool, which is done here
+// Most call sites should call startTransaction directly instead, however, initConnection is required
+// whenever we need to run queries without a transaction
+func initConnection(client *Client, database string) (*DBConnection, error) {
 	if database != "" && database != client.databaseName {
 		client = client.config.NewClient(database)
 	}
 	db, err := client.Connect()
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
+
+// startTransaction starts a new DB transaction on the specified database.
+// If the database is specified and different from the one configured in the provider,
+// it will create a new connection pool if needed.
+func startTransaction(client *Client, database string) (*sql.Tx, error) {
+	db, err := initConnection(client, database)
 	if err != nil {
 		return nil, err
 	}

--- a/postgresql/resource_postgresql_replication_slot.go
+++ b/postgresql/resource_postgresql_replication_slot.go
@@ -48,19 +48,15 @@ func resourcePostgreSQLReplicationSlotCreate(db *DBConnection, d *schema.Resourc
 	plugin := d.Get("plugin").(string)
 	databaseName := getDatabaseForReplicationSlot(d, db.client.databaseName)
 
-	txn, err := startTransaction(db.client, databaseName)
+	// NB: we use initConnection instead of startTransaction so that replication slots can be managed on replica servers too, for cascading replication
+	dbc, err := initConnection(db.client, databaseName)
 	if err != nil {
 		return err
 	}
-	defer deferredRollback(txn)
 
 	sql := "SELECT FROM pg_create_logical_replication_slot($1, $2)"
-	if _, err := txn.Exec(sql, name, plugin); err != nil {
+	if _, err := dbc.Exec(sql, name, plugin); err != nil {
 		return err
-	}
-
-	if err = txn.Commit(); err != nil {
-		return fmt.Errorf("error creating ReplicationSlot: %w", err)
 	}
 
 	d.SetId(generateReplicationSlotID(d, databaseName))
@@ -83,14 +79,14 @@ func resourcePostgreSQLReplicationSlotExists(db *DBConnection, d *schema.Resourc
 		return false, err
 	}
 
-	txn, err := startTransaction(db.client, database)
+	// NB: we use initConnection instead of startTransaction so that replication slots can be managed on replica servers too, for cascading replication
+	dbc, err := initConnection(db.client, database)
 	if err != nil {
 		return false, err
 	}
-	defer deferredRollback(txn)
 
 	query := "SELECT slot_name FROM pg_catalog.pg_replication_slots WHERE slot_name = $1 and database = $2"
-	err = txn.QueryRow(query, replicationSlotName, database).Scan(&ReplicationSlotName)
+	err = dbc.QueryRow(query, replicationSlotName, database).Scan(&ReplicationSlotName)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -111,17 +107,17 @@ func resourcePostgreSQLReplicationSlotReadImpl(db *DBConnection, d *schema.Resou
 		return err
 	}
 
-	txn, err := startTransaction(db.client, database)
+	// NB: we use initConnection instead of startTransaction so that replication slots can be managed on replica servers too, for cascading replication
+	dbc, err := initConnection(db.client, database)
 	if err != nil {
 		return err
 	}
-	defer deferredRollback(txn)
 
 	var replicationSlotPlugin string
 	query := `SELECT plugin ` +
 		`FROM pg_catalog.pg_replication_slots ` +
 		`WHERE slot_name = $1 AND database = $2`
-	err = txn.QueryRow(query, replicationSlotName, database).Scan(&replicationSlotPlugin)
+	err = dbc.QueryRow(query, replicationSlotName, database).Scan(&replicationSlotPlugin)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL ReplicationSlot (%s) not found for database %s", replicationSlotName, database)
@@ -144,19 +140,15 @@ func resourcePostgreSQLReplicationSlotDelete(db *DBConnection, d *schema.Resourc
 	replicationSlotName := d.Get("name").(string)
 	database := getDatabaseForReplicationSlot(d, db.client.databaseName)
 
-	txn, err := startTransaction(db.client, database)
+	// NB: we use initConnection instead of startTransaction so that replication slots can be managed on replica servers too, for cascading replication
+	dbc, err := initConnection(db.client, database)
 	if err != nil {
 		return err
 	}
-	defer deferredRollback(txn)
 
 	sql := "SELECT pg_drop_replication_slot($1)"
-	if _, err := txn.Exec(sql, replicationSlotName); err != nil {
+	if _, err := dbc.Exec(sql, replicationSlotName); err != nil {
 		return err
-	}
-
-	if err = txn.Commit(); err != nil {
-		return fmt.Errorf("error deleting ReplicationSlot: %w", err)
 	}
 
 	d.SetId("")


### PR DESCRIPTION
Hi !

This PR addresses https://github.com/cyrilgdn/terraform-provider-postgresql/issues/537.

The idea is that since pg 16, it's possible to create replication slots on replica servers, for cascading replication setups.
However, attempting to start a transaction on a replica will fail, as most resources on such a server are read-only.
Replication slots, however, can without issue be read, created, or deleted.

This PR removes any transaction opening from replication slot code, instead using direct db connection to run its commands.
Since there was only ever a single SQL statement per transaction, it should be safe not to use transactions for this resource.



Considering this is essentially the first time I'm writing go code, I'm not expecting this code to be mergeable as is, since I have no idea what the expected quality standards might be, nor how to write relevant tests.
The existing testsuite does pass, though.
Feel free to let me know if anything needs to be changed !


Regarding testing, I have started using this code to manage my own infrastructure (where, as you might expect, I need to create a replication slot on a pg replica), and so far, it works just fine. I'm not sure what more needs to be tested considering this resource is about as simple as it gets, but let me know if you want me to run any specific test !