### PR TITLE
fix: tolerate vendor-specific suffixes in PostgreSQL version string

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-	"unicode"
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -412,16 +412,21 @@ func fingerprintCapabilities(db *sql.DB) (*semver.Version, error) {
 		return nil, fmt.Errorf("error PostgreSQL version: %w", err)
 	}
 
-	// PostgreSQL 9.2.21 on x86_64-apple-darwin16.5.0, compiled by Apple LLVM version 8.1.0 (clang-802.0.42), 64-bit
-	// PostgreSQL 9.6.7, compiled by Visual C++ build 1800, 64-bit
-	fields := strings.FieldsFunc(pgVersion, func(c rune) bool {
-		return unicode.IsSpace(c) || c == ','
-	})
-	if len(fields) < 2 {
+	return parsePostgreSQLVersion(pgVersion)
+}
+
+// versionRe extracts the numeric version right after "PostgreSQL ", dropping vendor
+// suffixes (AWS RDS, TDE builds, ...) that aren't valid semver.
+var versionRe = regexp.MustCompile(`^PostgreSQL\s+(\d+(?:\.\d+){0,2})`)
+
+// parsePostgreSQLVersion extracts a semver.Version from a `SELECT VERSION()` result.
+func parsePostgreSQLVersion(pgVersion string) (*semver.Version, error) {
+	matches := versionRe.FindStringSubmatch(pgVersion)
+	if matches == nil {
 		return nil, fmt.Errorf("error determining the server version: %q", pgVersion)
 	}
 
-	version, err := semver.ParseTolerant(fields[1])
+	version, err := semver.ParseTolerant(matches[1])
 	if err != nil {
 		return nil, fmt.Errorf("error parsing version: %w", err)
 	}

--- a/postgresql/config_test.go
+++ b/postgresql/config_test.go
@@ -114,6 +114,44 @@ func newFlakyClient(driverName string, drv *flakyPingDriver, maxConnRetries, tim
 	}
 }
 
+func TestParsePostgreSQLVersion(t *testing.T) {
+	var tests = []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"PostgreSQL 9.2.21 on x86_64-apple-darwin16.5.0, compiled by Apple LLVM version 8.1.0 (clang-802.0.42), 64-bit", "9.2.21", false},
+		{"PostgreSQL 9.6.7, compiled by Visual C++ build 1800, 64-bit", "9.6.7", false},
+		{"PostgreSQL 13.23-rds.20260224 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit", "13.23.0", false},
+		{"PostgreSQL 16.2-rds.20240509 on aarch64-unknown-linux-gnu, compiled by aarch64-unknown-linux-gnu-gcc, 64-bit", "16.2.0", false},
+		{"PostgreSQL 13.14_TDE_X on x86_64-pc-linux-gnu, compiled by gcc, 64-bit", "13.14.0", false},
+		{"PostgreSQL 10 on x86_64-pc-linux-gnu, compiled by gcc, 64-bit", "10.0.0", false},
+		{"garbage with only one field", "", true},
+		{"PostgreSQL -not-a-version on x86_64", "", true},
+		{"not PostgreSQL 9.2.21", "", true},
+	}
+
+	for _, test := range tests {
+		got, err := parsePostgreSQLVersion(test.input)
+
+		if test.wantErr {
+			if err == nil {
+				t.Errorf("parsePostgreSQLVersion(%q) expected an error, got version %v", test.input, got)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("parsePostgreSQLVersion(%q) returned unexpected error: %v", test.input, err)
+			continue
+		}
+
+		if got.String() != test.want {
+			t.Errorf("parsePostgreSQLVersion(%q) = %v, want %v", test.input, got, test.want)
+		}
+	}
+}
+
 func TestConnectWithRetrySucceedsAfterTransientFailures(t *testing.T) {
 	drv := &flakyPingDriver{failuresBeforeSuccess: 2}
 	c := newFlakyClient("flaky-retry-success", drv, 5, 5)


### PR DESCRIPTION
AWS RDS and TDE-patched builds append non-semver metadata to the version reported by `SELECT VERSION()` (e.g. "13.23-rds.20260224", "13.14_TDE_X"), which breaks capability detection with:

  error parsing version: Invalid character(s) found in minor number

Extract fingerprintCapabilities' parsing logic into a standalone parsePostgreSQLVersion function and strip any trailing non-numeric suffix from the version field before passing it to semver.ParseTolerant, instead of special-casing individual vendor strings.

Closes:
* https://github.com/cyrilgdn/terraform-provider-postgresql/issues/657
* https://github.com/cyrilgdn/terraform-provider-postgresql/issues/273

Superseeds:
* https://github.com/cyrilgdn/terraform-provider-postgresql/pull/565