### PR TITLE
fix: postgresql_user_mapping read/import on managed PostgreSQL (RDS, Cloud SQL)

### DIFF
--- a/postgresql/resource_postgresql_user_mapping.go
+++ b/postgresql/resource_postgresql_user_mapping.go
@@ -105,6 +105,16 @@ func resourcePostgreSQLUserMappingReadImpl(db *DBConnection, d *schema.ResourceD
 	username := d.Get(userMappingUserNameAttr).(string)
 	serverName := d.Get(userMappingServerNameAttr).(string)
 
+	// On import only the ID ("<user_name>.<server_name>") is set, so derive the attributes from it
+	if username == "" && serverName == "" && d.Id() != "" {
+		parts := strings.SplitN(d.Id(), ".", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("invalid user mapping ID %q, expected <user_name>.<server_name>", d.Id())
+		}
+		username = parts[0]
+		serverName = parts[1]
+	}
+
 	txn, err := startTransaction(db.client, "")
 	if err != nil {
 		return err
@@ -112,10 +122,19 @@ func resourcePostgreSQLUserMappingReadImpl(db *DBConnection, d *schema.ResourceD
 	defer deferredRollback(txn)
 
 	var userMappingOptions []string
+	// Savepoint so that a permission error on information_schema._pg_user_mappings
+	// (not readable on some managed services, e.g. AWS RDS >= 17.9-R2, Google Cloud SQL)
+	// doesn't abort the transaction before the pg_user_mappings fallback runs
+	if _, err := txn.Exec("SAVEPOINT read_user_mapping"); err != nil {
+		return fmt.Errorf("could not create savepoint: %w", err)
+	}
 	query := "SELECT umoptions FROM information_schema._pg_user_mappings WHERE authorization_identifier = $1 and foreign_server_name = $2"
 	err = txn.QueryRow(query, username, serverName).Scan(pq.Array(&userMappingOptions))
 
 	if err != sql.ErrNoRows && err != nil {
+		if _, spErr := txn.Exec("ROLLBACK TO SAVEPOINT read_user_mapping"); spErr != nil {
+			return fmt.Errorf("error reading user mapping: %w", err)
+		}
 		// Fallback to pg_user_mappings table if information_schema._pg_user_mappings is not available
 		query := "SELECT umoptions FROM pg_user_mappings WHERE usename = $1 and srvname = $2"
 		err = txn.QueryRow(query, username, serverName).Scan(pq.Array(&userMappingOptions))
@@ -134,6 +153,16 @@ func resourcePostgreSQLUserMappingReadImpl(db *DBConnection, d *schema.ResourceD
 	for _, v := range userMappingOptions {
 		pair := strings.SplitN(v, "=", 2)
 		mappedOptions[pair[0]] = pair[1]
+	}
+
+	// pg_user_mappings masks umoptions for other roles' mappings; keep the options
+	// already in state rather than wiping them, which would cause a permanent diff
+	if len(mappedOptions) == 0 {
+		if prev, ok := d.GetOk(userMappingOptionsAttr); ok {
+			if prevOptions, isMap := prev.(map[string]any); isMap && len(prevOptions) > 0 {
+				mappedOptions = prevOptions
+			}
+		}
 	}
 
 	d.Set(userMappingUserNameAttr, username)

--- a/postgresql/resource_postgresql_user_mapping_test.go
+++ b/postgresql/resource_postgresql_user_mapping_test.go
@@ -40,6 +40,28 @@ func TestAccPostgresqlUserMapping_Basic(t *testing.T) {
 	})
 }
 
+func TestAccPostgresqlUserMapping_Import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureServer)
+			testSuperuserPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlUserMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPostgresqlUserMappingConfig,
+			},
+			{
+				ResourceName:      "postgresql_user_mapping.remote",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccPostgresqlUserMapping_Update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {


### PR DESCRIPTION
## Summary

`postgresql_user_mapping` read and import were broken on managed PostgreSQL services (AWS RDS ≥ 17.9-R2/18.x, Google Cloud SQL) that restrict access to `information_schema._pg_user_mappings`. Fixes #552, fixes #575.

## Problem

- **Read failed outright**: when the `information_schema._pg_user_mappings` query hit a permission error, the transaction was left aborted, so the intended `pg_user_mappings` fallback query never ran.
- **Import was broken**: the passthrough importer only sets the resource ID; `Read` never parsed it, so `user_name`/`server_name` stayed empty and every import came back "not found".
- **Permanent diff on the fallback path**: `pg_user_mappings` masks `umoptions` for mappings owned by another role, so once the fallback ran, the options would get wiped from state every refresh.

## Changes

- Wrap the `information_schema._pg_user_mappings` query in a `SAVEPOINT`, and `ROLLBACK TO SAVEPOINT` on error, so a permission error no longer poisons the transaction before the `pg_user_mappings` fallback runs.
- On import, derive `user_name`/`server_name` from the resource ID (`<user_name>.<server_name>`).
- When the fallback masks `umoptions`, keep whatever is already in state instead of overwriting it with an empty map.

## Testing

- Added `TestAccPostgresqlUserMapping_Import`, which fails against the old `Read` implementation with "Cannot import non-existent remote object" and passes with this fix.
- `go build ./...` and `go vet ./...` pass.

## Disclosure

This fix was developed with Claude Code (Anthropic) assistance, reviewed and tested by me before opening this PR. Happy to discuss any part of the change.